### PR TITLE
minimize iOS Safari UI on iOS 7.1 beta 2

### DIFF
--- a/src/templates/index.jade
+++ b/src/templates/index.jade
@@ -2,7 +2,7 @@ doctype
 html
   head
     meta(charset="utf-8")
-    meta(name="viewport", content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no")
+    meta(name="viewport", content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no, minimal-ui")
     meta(name='apple-mobile-web-app-capable', content='yes')
     meta(name="apple-mobile-web-app-status-bar-style", content="black")
     title My App


### PR DESCRIPTION
In iOS 7.1 beta 2 was added another `viewport` meta tag option: `minimal-ui`. Which slightly minimize Safari UI, thus it can create native app like feel.

You can observe diff:

_Without `minimal-ui` to the left and with `minimal-ui` to the right._

<a href="http://i.imgur.com/uKrRfoN.png" target="blank_"><img src="http://i.imgur.com/uKrRfoN.png" width="200"></a> <a href="http://i.imgur.com/NRAHuBQ.png" target="blank_"><img src="http://i.imgur.com/NRAHuBQ.png" width="200"></a>
