### PR TITLE
Convert .preloader from CSS to SVG

### DIFF
--- a/kitchen-sink/css/kitchen-sink.css
+++ b/kitchen-sink/css/kitchen-sink.css
@@ -69,26 +69,10 @@
 .ks-preloaders {
   text-align: center;
 }
-.ks-preloader-big {
+.ks-preloader-big:after {
   width: 42px;
   height: 42px;
-}
-.ks-preloader-big span {
-  background: red;
-}
-.ks-preloader-small {
-  width: 20px;
-  height: 20px;
-}
-.ks-preloader-small span {
-  background: blue;
-}
-.ks-preloader-xsmall {
-  width: 12px;
-  height: 12px;
-}
-.ks-preloader-xsmall span {
-  background: green;
+  background-size: 42px;
 }
 .page[data-page="messages"] .page-content {
   padding-bottom: 44px;

--- a/kitchen-sink/less/kitchen-sink.less
+++ b/kitchen-sink/less/kitchen-sink.less
@@ -77,26 +77,10 @@
 .ks-preloaders {
     text-align: center;
 }
-.ks-preloader-big {
+.ks-preloader-big:after {
     width: 42px;
     height: 42px;
-    span {
-        background: red;
-    }
-}
-.ks-preloader-small {
-    width: 20px;
-    height: 20px;
-    span {
-        background: blue;
-    }
-}
-.ks-preloader-xsmall {
-    width: 12px;
-    height: 12px;
-    span {
-        background: green;
-    }
+    background-size: 42px;
 }
 .page[data-page="messages"] {
     .page-content {

--- a/kitchen-sink/preloader.html
+++ b/kitchen-sink/preloader.html
@@ -10,13 +10,13 @@
   <div data-page="preloader" class="page">
     <div class="page-content">
       <div class="content-block">
-        <p>What about preloader (ajax loader)? Framework 7 has nice one. F7 preloader made with pure CSS so you can resize it and change its color with ease. Its HTML is pretty easy, it is just a .preloader element with 12 spans in it. Here are examples:</p>
+        <p>How about an activity indicator? Framework 7 has a nice one. The F7 preloader is made with SVG and animated with CSS so it can be easily resized. Two options are available: the default is for a light background and another on a dark background. The HTML is pretty easy, just add a .preloader class to any element. For the dark background option, also add a .dark class. Here are some examples:</p>
       </div>
       <div class="content-block row ks-preloaders">
-        <div class="col-25">Default:<br><span class="preloader"><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span></span></div>
-        <div class="col-25">Big:<br><span class="preloader ks-preloader-big"><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span></span></div>
-        <div class="col-25">Small:<br><span class="preloader ks-preloader-small"><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span></span></div>
-        <div class="col-25">X-Small:<br><span class="preloader ks-preloader-xsmall"><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span></span></div>
+        <div class="col-25">Default:<br><span class="preloader"></span></div>
+        <div class="col-25" style="background-color: #333;">Dark:<br><span class="dark preloader"></span></div>
+        <div class="col-25">Big:<br><span class="preloader ks-preloader-big"></span></div>
+        <div class="col-25" style="background-color: #333;">Dark:<br><span class="dark preloader ks-preloader-big"></span></div>
       </div>
       <div class="content-block">
         <p>With <b>app.showPreloader()</b> you can call modal window with preloader:</p><a href="#" class="button demo-preloader">Open preloader modal</a>

--- a/src/less/preloader.less
+++ b/src/less/preloader.less
@@ -1,70 +1,46 @@
 /* === Preloader === */
-.preloader {
-    width: 28px;
-    height: 28px;
+.preloader:after {
     display: inline-block;
-    position: relative;
-    span {
-        width: 2/28*100%; //Should be 2 pixels
-        height: 8/28*100%; //Should be 8 pixels
-        min-width: 1px;
-        min-height: 1px;
-        background: #575f6c;
-        display: block;
-        position: absolute;
-        left: 50%;
-        margin-left: -1/28*100%; // Should be -1px
-        top: 0;
-        .transform-origin(50% 14/8*100%); //Should be 50% 14px
-        opacity: 0;
-    }
+    content: "";
+    width: 20px;
+    height: 20px;
+    // Note: Firefox requires '#' to be encoded as '%23' with data URIs
+    background-image: url("data:image/svg+xml;charset=utf-8,<svg viewBox='0 0 120 120' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'><defs><line id='l' x1='60' x2='60' y1='7' y2='27' stroke='%238c8c8c' stroke-width='11' stroke-linecap='round'/></defs><g><use xlink:href='%23l' opacity='.27'/><use xlink:href='%23l' opacity='.27' transform='rotate(30 60,60)'/><use xlink:href='%23l' opacity='.27' transform='rotate(60 60,60)'/><use xlink:href='%23l' opacity='.27' transform='rotate(90 60,60)'/><use xlink:href='%23l' opacity='.27' transform='rotate(120 60,60)'/><use xlink:href='%23l' opacity='.27' transform='rotate(150 60,60)'/><use xlink:href='%23l' opacity='.37' transform='rotate(180 60,60)'/><use xlink:href='%23l' opacity='.46' transform='rotate(210 60,60)'/><use xlink:href='%23l' opacity='.56' transform='rotate(240 60,60)'/><use xlink:href='%23l' opacity='.66' transform='rotate(270 60,60)'/><use xlink:href='%23l' opacity='.75' transform='rotate(300 60,60)'/><use xlink:href='%23l' opacity='.85' transform='rotate(330 60,60)'/></g></svg>");
+    background-position: 50%;
+    background-size: 20px;
+    background-repeat: no-repeat;
+    -webkit-transform-origin: 50%;
+    transform-origin: 50%;
+    -webkit-animation: spin 1s step-end infinite;
+    animation: spin 1s step-end infinite;
 }
-.modal .preloader {
+.dark .preloader:after, .dark.preloader:after {
+    background-image: url("data:image/svg+xml;charset=utf-8,<svg viewBox='0 0 120 120' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'><defs><line id='l' x1='60' x2='60' y1='7' y2='27' stroke='%23fff' stroke-width='11' stroke-linecap='round'/></defs><g><use xlink:href='%23l' opacity='.27'/><use xlink:href='%23l' opacity='.27' transform='rotate(30 60,60)'/><use xlink:href='%23l' opacity='.27' transform='rotate(60 60,60)'/><use xlink:href='%23l' opacity='.27' transform='rotate(90 60,60)'/><use xlink:href='%23l' opacity='.27' transform='rotate(120 60,60)'/><use xlink:href='%23l' opacity='.27' transform='rotate(150 60,60)'/><use xlink:href='%23l' opacity='.37' transform='rotate(180 60,60)'/><use xlink:href='%23l' opacity='.46' transform='rotate(210 60,60)'/><use xlink:href='%23l' opacity='.56' transform='rotate(240 60,60)'/><use xlink:href='%23l' opacity='.66' transform='rotate(270 60,60)'/><use xlink:href='%23l' opacity='.75' transform='rotate(300 60,60)'/><use xlink:href='%23l' opacity='.85' transform='rotate(330 60,60)'/></g></svg>");
+}
+.modal .preloader:after {
     width: 34px;
     height: 34px;
+    background-size: 34px;
 }
-.preloader-loop(@i) when (@i < 13){
-    .preloader span:nth-child(@{i}) {
-        @deg: (@i - 1) * 30deg;
-        @duration: 900ms;
-        @delay: (@i - 1) * (@duration/12);
-        .transform(rotate(@deg));
-        .animation(~"preloaderStickPulsate @{duration} @{delay} infinite");
-    }
-    .preloader-loop(@i + 1);
-}
-.preloader-loop(1);
-
-@-webkit-keyframes preloaderStickPulsate {
-    0% {
-        opacity: 1;
-    }
-    90% {
-        opacity: 0;
-    }
-    100% {
-        opacity: 1;
+@-webkit-keyframes spin {
+    .preloader-loop(0);
+    .preloader-loop(@i) when (@i <= 12) {
+        @j: ((@i * (1/12)) * 100%);
+        @{j} {
+            @deg: (@i) * 30deg;
+            -webkit-transform: rotate(@deg);
+        }
+        .preloader-loop(@i + 1);
     }
 }
-@-moz-keyframes preloaderStickPulsate {
-    0% {
-        opacity: 1;
-    }
-    90% {
-        opacity: 0;
-    }
-    100% {
-        opacity: 1;
-    }
-}
-@keyframes preloaderStickPulsate {
-    0% {
-        opacity: 1;
-    }
-    90% {
-        opacity: 0;
-    }
-    100% {
-        opacity: 1;
+@keyframes spin {
+    .preloader-loop(0);
+    .preloader-loop(@i) when (@i <= 12) {
+        @j: ((@i * (1/12)) * 100%);
+        @{j} {
+            @deg: (@i) * 30deg;
+            transform: rotate(@deg);
+        }
+        .preloader-loop(@i + 1);
     }
 }


### PR DESCRIPTION
I reimplemented the .preloader class from the pure CSS + non-semantic HTML elements to SVG with CSS animation.

The drawback is that it is not as easily re-colored, but two versions based on what I've seen in iOS are included. The default is for use on a light background and another for use on a dark background.  Both are pixel perfect including opacity.
