### PR TITLE
Remove duplicate `position: relative`

### DIFF
--- a/src/less/views.less
+++ b/src/less/views.less
@@ -5,7 +5,6 @@
     z-index: 5000;
 }
 .views {
-    position: relative;
     .scrollable();
 }
 .view {


### PR DESCRIPTION
`position: relative` is set on `.views` immediately above.
