### PR TITLE
Remove duplicate `height: 100%`

### DIFF
--- a/src/less/pages.less
+++ b/src/less/pages.less
@@ -10,7 +10,6 @@
     .full-size();
     overflow: hidden;
     background: #efeff4;
-    height: 100%;
     .translate3d(0,0,0);
     opacity: 1;
     .box-shadow(0 0 0 rgba(0,0,0,0));


### PR DESCRIPTION
`height: 100%` is set on `.page` by the call to `.full-size()` immediately above.
