### PR TITLE
Add `navbarInit` event.

### DIFF
--- a/src/js/navbars.js
+++ b/src/js/navbars.js
@@ -1,6 +1,25 @@
 /*======================================================
 ************   Navbars && Toolbars   ************
 ======================================================*/
+// On Navbar Init Callback
+app.navbarInitCallback = function (view, pageContainer, navbar, navbarInnerContainer, url, position) {
+    var eventData = {
+        navbar: {
+            container: navbar[0],
+            innerContainer: navbarInnerContainer
+        },
+        page: {
+            url: url,
+            query: $.parseUrlQuery(url || ''),
+            container: pageContainer,
+            name: $(pageContainer).attr('data-page'),
+            view: view,
+            from: position
+        }
+    };
+    // Navbar Init Callback
+    $(navbarInnerContainer).trigger('navbarInit', eventData);
+};
 app.sizeNavbars = function (viewContainer) {
     var navbarInner = viewContainer ? $(viewContainer).find('.navbar .navbar-inner:not(.cached)') : $('.navbar .navbar-inner:not(.cached)');
     navbarInner.each(function () {

--- a/src/js/pages.js
+++ b/src/js/pages.js
@@ -280,6 +280,9 @@ function _load(view, url, content) {
     if (dynamicNavbar) {
         newNavbarInner.addClass('navbar-on-right');
         navbar.append(newNavbarInner[0]);
+
+        // Navbar Init Events
+        app.navbarInitCallback(view, newPage[0], navbar, newNavbarInner[0], url, 'right');
     }
 
     // save content areas into view's cache


### PR DESCRIPTION
As discussed in issue #35, adding  a `navbarInit` event would benefit those who integrate F7 with other frameworks (e.g. AngularJS) .
