### PR TITLE
Added .tablet-inset support for content blocks

### DIFF
--- a/src/less/content-block.less
+++ b/src/less/content-block.less
@@ -35,3 +35,15 @@
         border-bottom-width: 0.5px;
     }
 }
+@media all and (min-width:768px) {
+    .content-block.tablet-inset {
+        margin-left: 15px;
+        margin-right: 15px;
+        border-radius: 7px
+    }
+    
+    .content-block.tablet-inset .content-block-inner {
+    	border: none;
+    	border-radius: 7px;
+    }
+}


### PR DESCRIPTION
As lists do have .tablet-inset support, why should content blocks be left out?
