### PR TITLE
fix android touchmove event bug in photo-browser

### DIFF
--- a/src/js/photo-browser.js
+++ b/src/js/photo-browser.js
@@ -374,7 +374,7 @@ var PhotoBrowser = function (params) {
 
     pb.onSlideTouchStart = function (e) {
         if (imageIsTouched) return;
-        if (app.device.os=='android') e.preventDefault();
+        if (app.device.os === 'android') e.preventDefault();
         imageIsTouched = true;
         imageTouchesStart.x = e.type === 'touchstart' ? e.targetTouches[0].pageX : e.pageX;
         imageTouchesStart.y = e.type === 'touchstart' ? e.targetTouches[0].pageY : e.pageY;


### PR DESCRIPTION
without this fix you cant scroll zommed image in the photo-browser
you can read about it here:
http://uihacker.blogspot.tw/2011/01/android-touchmove-event-bug.html
