### PR TITLE
Switching active tabs based on .tabs

### DIFF
--- a/src/js/tabs.js
+++ b/src/js/tabs.js
@@ -48,7 +48,7 @@ app.showTab = function (tab, tabLink) {
     }
     if (tabLink.length === 0) return;
 
-    tabs.find('.tab.active').removeClass('active');
+    tabs.find('.tab-link.active').removeClass('active');
     tabLink.addClass('active');
     
     return true;


### PR DESCRIPTION
Switching active tabs based on .tabs, not on the parent of the current t...ab, therefore also useable with a list; as discussed in https://github.com/thomasf1/Framework7/commit/eece04e10e6285201633188fb5c35b1de7527960

I think this is a more elegant way of doing things, as the parent could include non-tabs with a class active; or as in my case the parent isn´t the right scope.
