### PR TITLE
Set height of tab icons in a 'tab-link' to 30px (rather than default 20px).

### DIFF
--- a/src/less/toolbars.less
+++ b/src/less/toolbars.less
@@ -144,6 +144,9 @@
         -ms-flex-direction: column;
         -webkit-flex-direction: column;
         flex-direction: column;
+        i.icon {
+            height: 30px;
+        }
     }
 }
 .tabbar-labels {


### PR DESCRIPTION
It would seem better to just be able to say that all `tab-link` icons in a tabbar are implicitly given the needed height of 30px, over default icon class height of 20px.

``` html
<div class="toolbar tabbar tabbar-labels">
    <div class="toolbar-inner">
         <a href="#" class="tab-link">
            <i class="icon icon-camera"></i>
            <span class="tabbar-label">Camera</span>
        < /a>
    </div>
</div>
```

Makes more sense semantically, and it just works without any additional effort, save for specifying the icon you want to use. Spent too long figuring out this wasn't already the case.
