### PR TITLE
Incorrect tabbar icon height selector during merge.

### DIFF
--- a/src/less/icons.less
+++ b/src/less/icons.less
@@ -96,7 +96,3 @@ i.icon {
         font-weight: 100;
     }
 }
-
-.tabbar.tabbar-labels a.tab-link i.icon {
-    height: 30px;
-}

--- a/src/less/toolbars.less
+++ b/src/less/toolbars.less
@@ -145,6 +145,9 @@
         -webkit-flex-direction: column;
         flex-direction: column;
     }
+    a.tab-link i.icon {
+      height: 30px !important;
+    }
 }
 .tabbar-labels {
     height: 50px;


### PR DESCRIPTION
You brought the i.icon height override in at the wrong level, so it isn't being applied.
