### PR TITLE
Fix #238 - Change cache.push order

### DIFF
--- a/src/js/xhr.js
+++ b/src/js/xhr.js
@@ -39,7 +39,6 @@ app.get = function (url, view, ignoreCache, callback) {
         start: app.params.onAjaxStart,
         complete: function (xhr) {
             if (xhr.status === 200 || xhr.status === 0) {
-                callback(xhr.responseText, false);
                 if (app.params.cache && !ignoreCache) {
                     app.removeFromCache(_url);
                     app.cache.push({
@@ -48,6 +47,7 @@ app.get = function (url, view, ignoreCache, callback) {
                         content: xhr.responseText
                     });
                 }
+                callback(xhr.responseText, false);
             }
             else {
                 callback(xhr.responseText, true);


### PR DESCRIPTION
Change order of cache function, now the callback runs after the
app.cache.push, so the cache is set anyway if enabled.
