### PR TITLE
Added onInit event for Sliders

### DIFF
--- a/src/js/slider.js
+++ b/src/js/slider.js
@@ -503,6 +503,9 @@ var Slider = function (container, params) {
         else s.updateClasses();
         s.attachEvents();
         if (s.params.autoplay) s.startAutoplay();
+        if (typeof s.params.onInit === 'function') {
+	        s.params.onInit();
+        }
     };
     s.update = function () {
         if (s.params.loop) s.createLoop();


### PR DESCRIPTION
Sliders do not have an event handler for initializing yet. This commit adds an 'onInit' event to Sliders so functions can be called when initializing them.
