### PR TITLE
D7 element width - no need for padding substraction

### DIFF
--- a/src/js/dom7-methods.js
+++ b/src/js/dom7-methods.js
@@ -269,7 +269,7 @@ Dom7.prototype = {
         }
         else {
             if (this.length > 0) {
-                return parseFloat(this.css('width')) - parseFloat(this.css('padding-left')) - parseFloat(this.css('padding-right'));
+                return parseFloat(this.css('width'));
             }
             else {
                 return null;


### PR DESCRIPTION
Maybe I didnt catch some old browser issues;
but current Safari & Chrome shows me that: http://jsfiddle.net/rgva8nr6/1/
