### PR TITLE
Add `blured` class for navbar/toolbar

### DIFF
--- a/kitchen-sink/index.html
+++ b/kitchen-sink/index.html
@@ -148,13 +148,13 @@
     </div>
     <div class="views">
       <div class="view view-main">
-        <div class="navbar">
+        <div class="navbar blured">
           <div class="navbar-inner">
             <div class="center sliding">Framework7</div>
             <div class="right"><a href="#" class="open-panel link icon-only"><i class="icon icon-bars"></i></a></div>
           </div>
         </div>
-        <div class="toolbar">
+        <div class="navbar blured">
           <div class="toolbar-inner"><a href="#" class="link">Dummy Link</a><a href="#" data-popover=".popover-menu" class="open-popover link">Menu</a></div>
         </div>
         <div class="pages navbar-through toolbar-through">

--- a/kitchen-sink/index.html
+++ b/kitchen-sink/index.html
@@ -148,13 +148,13 @@
     </div>
     <div class="views">
       <div class="view view-main">
-        <div class="navbar blured">
+        <div class="navbar blurred">
           <div class="navbar-inner">
             <div class="center sliding">Framework7</div>
             <div class="right"><a href="#" class="open-panel link icon-only"><i class="icon icon-bars"></i></a></div>
           </div>
         </div>
-        <div class="toolbar blured">
+        <div class="toolbar blurred">
           <div class="toolbar-inner"><a href="#" class="link">Dummy Link</a><a href="#" data-popover=".popover-menu" class="open-popover link">Menu</a></div>
         </div>
         <div class="pages navbar-through toolbar-through">

--- a/kitchen-sink/index.html
+++ b/kitchen-sink/index.html
@@ -22,87 +22,87 @@
       <div class="content-block-title">Framework7 Kitchen Sink</div>
       <div class="list-block">
         <ul>
-          <li><a href="modals.html" class="close-panel item-link"> 
+          <li><a href="modals.html" class="close-panel item-link">
               <div class="item-content">
                 <div class="item-media"><i class="icon icon-f7"></i></div>
-                <div class="item-inner"> 
+                <div class="item-inner">
                   <div class="item-title">Modals</div>
                 </div>
               </div></a></li>
           <li><a href="popover.html" class="close-panel item-link">
               <div class="item-content">
                 <div class="item-media"><i class="icon icon-f7"></i></div>
-                <div class="item-inner"> 
+                <div class="item-inner">
                   <div class="item-title">Popover</div>
                 </div>
               </div></a></li>
           <li><a href="tabs.html" class="close-panel item-link">
               <div class="item-content">
                 <div class="item-media"><i class="icon icon-f7"></i></div>
-                <div class="item-inner"> 
+                <div class="item-inner">
                   <div class="item-title">Tabs</div>
                 </div>
               </div></a></li>
           <li><a href="panels.html" class="close-panel item-link">
               <div class="item-content">
                 <div class="item-media"><i class="icon icon-f7"></i></div>
-                <div class="item-inner"> 
+                <div class="item-inner">
                   <div class="item-title">Side Panels</div>
                 </div>
               </div></a></li>
           <li><a href="list-view.html" class="close-panel item-link">
               <div class="item-content">
                 <div class="item-media"><i class="icon icon-f7"></i></div>
-                <div class="item-inner"> 
+                <div class="item-inner">
                   <div class="item-title">List View</div>
                 </div>
               </div></a></li>
           <li><a href="swipe-delete.html" class="close-panel item-link">
               <div class="item-content">
                 <div class="item-media"><i class="icon icon-f7"></i></div>
-                <div class="item-inner"> 
+                <div class="item-inner">
                   <div class="item-title">Swipe To Delete</div>
                 </div>
               </div></a></li>
           <li><a href="forms.html" class="close-panel item-link">
               <div class="item-content">
                 <div class="item-media"><i class="icon icon-f7"></i></div>
-                <div class="item-inner"> 
+                <div class="item-inner">
                   <div class="item-title">Forms</div>
                 </div>
               </div></a></li>
           <li><a href="messages.html" class="close-panel item-link">
               <div class="item-content">
                 <div class="item-media"><i class="icon icon-f7"></i></div>
-                <div class="item-inner"> 
+                <div class="item-inner">
                   <div class="item-title">Messages</div>
                 </div>
               </div></a></li>
           <li><a href="grid.html" class="close-panel item-link">
               <div class="item-content">
                 <div class="item-media"><i class="icon icon-f7"></i></div>
-                <div class="item-inner"> 
+                <div class="item-inner">
                   <div class="item-title">Grid</div>
                 </div>
               </div></a></li>
           <li><a href="preloader.html" class="close-panel item-link">
               <div class="item-content">
                 <div class="item-media"><i class="icon icon-f7"></i></div>
-                <div class="item-inner"> 
+                <div class="item-inner">
                   <div class="item-title">Preloader</div>
                 </div>
               </div></a></li>
-          <li><a href="bars.html" class="close-panel item-link"> 
+          <li><a href="bars.html" class="close-panel item-link">
               <div class="item-content">
                 <div class="item-media"><i class="icon icon-f7"></i></div>
-                <div class="item-inner"> 
+                <div class="item-inner">
                   <div class="item-title">Navbars And Toolbars</div>
                 </div>
               </div></a></li>
           <li><a href="transitions.html" class="close-panel item-link">
               <div class="item-content">
                 <div class="item-media"><i class="icon icon-f7"></i></div>
-                <div class="item-inner"> 
+                <div class="item-inner">
                   <div class="item-title">Transitions And Effects</div>
                 </div>
               </div></a></li>
@@ -121,21 +121,21 @@
         </div>
         <div class="pages navbar-through">
           <div data-page="panel-right1" class="page">
-            <div class="page-content"> 
+            <div class="page-content">
               <div class="content-block">
                 <p>This is a right side panel. You can close it by clicking outsite or on this link: <a href="#" class="close-panel">close me</a>. You can put here anything, even another isolated view, try it:</p>
               </div>
               <div class="list-block">
                 <ul>
-                  <li><a href="panel-right2.html" class="item-link"> 
+                  <li><a href="panel-right2.html" class="item-link">
                       <div class="item-content">
-                        <div class="item-inner"> 
+                        <div class="item-inner">
                           <div class="item-title">Right panel page 2</div>
                         </div>
                       </div></a></li>
                   <li><a href="panel-right3.html" class="item-link">
                       <div class="item-content">
-                        <div class="item-inner"> 
+                        <div class="item-inner">
                           <div class="item-title">Right panel page 3</div>
                         </div>
                       </div></a></li>
@@ -154,7 +154,7 @@
             <div class="right"><a href="#" class="open-panel link icon-only"><i class="icon icon-bars"></i></a></div>
           </div>
         </div>
-        <div class="navbar blured">
+        <div class="toolbar blured">
           <div class="toolbar-inner"><a href="#" class="link">Dummy Link</a><a href="#" data-popover=".popover-menu" class="open-popover link">Menu</a></div>
         </div>
         <div class="pages navbar-through toolbar-through">
@@ -165,213 +165,213 @@
               <div class="content-block-title">Framework7 Kitchen Sink</div>
               <div class="list-block">
                 <ul>
-                  <li><a href="modals.html" class="item-link"> 
+                  <li><a href="modals.html" class="item-link">
                       <div class="item-content">
                         <div class="item-media"><i class="icon icon-f7"></i></div>
-                        <div class="item-inner"> 
+                        <div class="item-inner">
                           <div class="item-title">Modals</div>
                         </div>
                       </div></a></li>
-                  <li><a href="popover.html" class="item-link"> 
+                  <li><a href="popover.html" class="item-link">
                       <div class="item-content">
                         <div class="item-media"><i class="icon icon-f7"></i></div>
-                        <div class="item-inner"> 
+                        <div class="item-inner">
                           <div class="item-title">Popover</div>
                         </div>
                       </div></a></li>
-                  <li><a href="tabs.html" class="item-link"> 
+                  <li><a href="tabs.html" class="item-link">
                       <div class="item-content">
                         <div class="item-media"><i class="icon icon-f7"></i></div>
-                        <div class="item-inner"> 
+                        <div class="item-inner">
                           <div class="item-title">Tabs</div>
                         </div>
                       </div></a></li>
-                  <li><a href="panels.html" class="item-link"> 
+                  <li><a href="panels.html" class="item-link">
                       <div class="item-content">
                         <div class="item-media"><i class="icon icon-f7"></i></div>
-                        <div class="item-inner"> 
+                        <div class="item-inner">
                           <div class="item-title">Side Panels</div>
                         </div>
                       </div></a></li>
-                  <li><a href="list-view.html" class="item-link"> 
+                  <li><a href="list-view.html" class="item-link">
                       <div class="item-content">
                         <div class="item-media"><i class="icon icon-f7"></i></div>
-                        <div class="item-inner"> 
+                        <div class="item-inner">
                           <div class="item-title">List View</div>
                         </div>
                       </div></a></li>
-                  <li><a href="media-lists.html" class="item-link"> 
+                  <li><a href="media-lists.html" class="item-link">
                       <div class="item-content">
                         <div class="item-media"><i class="icon icon-f7"></i></div>
-                        <div class="item-inner"> 
+                        <div class="item-inner">
                           <div class="item-title">Media Lists</div>
                         </div>
                       </div></a></li>
-                  <li><a href="contacts.html" class="item-link"> 
+                  <li><a href="contacts.html" class="item-link">
                       <div class="item-content">
                         <div class="item-media"><i class="icon icon-f7"></i></div>
-                        <div class="item-inner"> 
+                        <div class="item-inner">
                           <div class="item-title">Contacts List</div>
                         </div>
                       </div></a></li>
-                  <li><a href="swipe-delete.html" class="item-link"> 
+                  <li><a href="swipe-delete.html" class="item-link">
                       <div class="item-content">
                         <div class="item-media"><i class="icon icon-f7"></i></div>
-                        <div class="item-inner"> 
+                        <div class="item-inner">
                           <div class="item-title">Swipe To Delete</div>
                         </div>
                       </div></a></li>
                   <li><a href="sortable-list.html" class="item-link">
                       <div class="item-content">
                         <div class="item-media"><i class="icon icon-f7"></i></div>
-                        <div class="item-inner"> 
+                        <div class="item-inner">
                           <div class="item-title">Sortable List</div>
                         </div>
                       </div></a></li>
-                  <li><a href="accordion.html" class="item-link"> 
+                  <li><a href="accordion.html" class="item-link">
                       <div class="item-content">
                         <div class="item-media"><i class="icon icon-f7"></i></div>
-                        <div class="item-inner"> 
+                        <div class="item-inner">
                           <div class="item-title">Accordion</div>
                         </div>
                       </div></a></li>
-                  <li><a href="pull-to-refresh.html" class="item-link"> 
+                  <li><a href="pull-to-refresh.html" class="item-link">
                       <div class="item-content">
                         <div class="item-media"><i class="icon icon-f7"></i></div>
-                        <div class="item-inner"> 
+                        <div class="item-inner">
                           <div class="item-title">Pull To Refresh</div>
                         </div>
                       </div></a></li>
-                  <li><a href="forms.html" class="item-link"> 
+                  <li><a href="forms.html" class="item-link">
                       <div class="item-content">
                         <div class="item-media"><i class="icon icon-f7"></i></div>
-                        <div class="item-inner"> 
+                        <div class="item-inner">
                           <div class="item-title">Forms</div>
                         </div>
                       </div></a></li>
                   <li><a href="cards.html" class="item-link">
                       <div class="item-content">
                         <div class="item-media"><i class="icon icon-f7"></i></div>
-                        <div class="item-inner"> 
+                        <div class="item-inner">
                           <div class="item-title">Cards</div>
                         </div>
                       </div></a></li>
                   <li><a href="picker.html" class="item-link">
                       <div class="item-content">
                         <div class="item-media"><i class="icon icon-f7"></i></div>
-                        <div class="item-inner"> 
+                        <div class="item-inner">
                           <div class="item-title">Picker</div>
                         </div>
                       </div></a></li>
                   <li><a href="calendar.html" class="item-link">
                       <div class="item-content">
                         <div class="item-media"><i class="icon icon-f7"></i></div>
-                        <div class="item-inner"> 
+                        <div class="item-inner">
                           <div class="item-title">Calendar / Datepicker</div>
                         </div>
                       </div></a></li>
-                  <li><a href="messages.html" class="item-link"> 
+                  <li><a href="messages.html" class="item-link">
                       <div class="item-content">
                         <div class="item-media"><i class="icon icon-f7"></i></div>
-                        <div class="item-inner"> 
+                        <div class="item-inner">
                           <div class="item-title">Messages</div>
                         </div>
                       </div></a></li>
-                  <li><a href="grid.html" class="item-link"> 
+                  <li><a href="grid.html" class="item-link">
                       <div class="item-content">
                         <div class="item-media"><i class="icon icon-f7"></i></div>
-                        <div class="item-inner"> 
+                        <div class="item-inner">
                           <div class="item-title">Grid</div>
                         </div>
                       </div></a></li>
-                  <li><a href="preloader.html" class="item-link"> 
+                  <li><a href="preloader.html" class="item-link">
                       <div class="item-content">
                         <div class="item-media"><i class="icon icon-f7"></i></div>
-                        <div class="item-inner"> 
+                        <div class="item-inner">
                           <div class="item-title">Preloader</div>
                         </div>
                       </div></a></li>
-                  <li><a href="bars.html" class="item-link"> 
+                  <li><a href="bars.html" class="item-link">
                       <div class="item-content">
                         <div class="item-media"><i class="icon icon-f7"></i></div>
-                        <div class="item-inner"> 
+                        <div class="item-inner">
                           <div class="item-title">Navbars And Toolbars</div>
                         </div>
                       </div></a></li>
-                  <li><a href="searchbar.html" class="item-link"> 
+                  <li><a href="searchbar.html" class="item-link">
                       <div class="item-content">
                         <div class="item-media"><i class="icon icon-f7"></i></div>
-                        <div class="item-inner"> 
+                        <div class="item-inner">
                           <div class="item-title">Search Bar</div>
                         </div>
                       </div></a></li>
-                  <li><a href="swiper.html" class="item-link"> 
+                  <li><a href="swiper.html" class="item-link">
                       <div class="item-content">
                         <div class="item-media"><i class="icon icon-f7"></i></div>
-                        <div class="item-inner"> 
+                        <div class="item-inner">
                           <div class="item-title">Swiper Slider</div>
                         </div>
                       </div></a></li>
-                  <li><a href="photo-browser.html" class="item-link"> 
+                  <li><a href="photo-browser.html" class="item-link">
                       <div class="item-content">
                         <div class="item-media"><i class="icon icon-f7"></i></div>
-                        <div class="item-inner"> 
+                        <div class="item-inner">
                           <div class="item-title">Photo Browser</div>
                         </div>
                       </div></a></li>
-                  <li><a href="infinite-scroll.html" class="item-link"> 
+                  <li><a href="infinite-scroll.html" class="item-link">
                       <div class="item-content">
                         <div class="item-media"><i class="icon icon-f7"></i></div>
-                        <div class="item-inner"> 
+                        <div class="item-inner">
                           <div class="item-title">Infinite Scroll</div>
                         </div>
                       </div></a></li>
-                  <li><a href="virtual-list.html" class="item-link"> 
+                  <li><a href="virtual-list.html" class="item-link">
                       <div class="item-content">
                         <div class="item-media"><i class="icon icon-f7"></i></div>
-                        <div class="item-inner"> 
+                        <div class="item-inner">
                           <div class="item-title">Virtual List</div>
                         </div>
                       </div></a></li>
-                  <li><a href="notifications.html" class="item-link"> 
+                  <li><a href="notifications.html" class="item-link">
                       <div class="item-content">
                         <div class="item-media"><i class="icon icon-f7"></i></div>
-                        <div class="item-inner"> 
+                        <div class="item-inner">
                           <div class="item-title">Notifications</div>
                         </div>
                       </div></a></li>
-                  <li><a href="lazy-load.html" class="item-link"> 
+                  <li><a href="lazy-load.html" class="item-link">
                       <div class="item-content">
                         <div class="item-media"><i class="icon icon-f7"></i></div>
-                        <div class="item-inner"> 
+                        <div class="item-inner">
                           <div class="item-title">Lazy Load Images</div>
                         </div>
                       </div></a></li>
-                  <li><a href="login-screen.html" class="item-link"> 
+                  <li><a href="login-screen.html" class="item-link">
                       <div class="item-content">
                         <div class="item-media"><i class="icon icon-f7"></i></div>
-                        <div class="item-inner"> 
+                        <div class="item-inner">
                           <div class="item-title">Login Screen</div>
                         </div>
                       </div></a></li>
-                  <li><a href="color-themes.html" class="item-link"> 
+                  <li><a href="color-themes.html" class="item-link">
                       <div class="item-content">
                         <div class="item-media"><i class="icon icon-f7"></i></div>
-                        <div class="item-inner"> 
+                        <div class="item-inner">
                           <div class="item-title">Color Themes</div>
                         </div>
                       </div></a></li>
                   <li><a href="#" class="item-link ks-generate-page">
                       <div class="item-content">
                         <div class="item-media"><i class="icon icon-f7"></i></div>
-                        <div class="item-inner"> 
+                        <div class="item-inner">
                           <div class="item-title">Dynamically Generated Content</div>
                         </div>
                       </div></a></li>
-                  <li><a href="transitions.html" class="item-link"> 
+                  <li><a href="transitions.html" class="item-link">
                       <div class="item-content">
                         <div class="item-media"><i class="icon icon-f7"></i></div>
-                        <div class="item-inner"> 
+                        <div class="item-inner">
                           <div class="item-title">Transitions And Effects</div>
                         </div>
                       </div></a></li>
@@ -466,7 +466,7 @@
               <div class="list-block">
                 <ul>
                   <li class="item-content">
-                    <div class="item-inner"> 
+                    <div class="item-inner">
                       <div class="item-title label">Username</div>
                       <div class="item-input">
                         <input type="text" name="username" placeholder="Your username">
@@ -474,7 +474,7 @@
                     </div>
                   </li>
                   <li class="item-content">
-                    <div class="item-inner"> 
+                    <div class="item-inner">
                       <div class="item-title label">Password</div>
                       <div class="item-input">
                         <input type="password" name="password" placeholder="Your password">

--- a/kitchen-sink/js/kitchen-sink.js
+++ b/kitchen-sink/js/kitchen-sink.js
@@ -289,30 +289,30 @@ var photoBrowserPhotos = [
     
 ];
 var photoBrowserStandalone = myApp.photoBrowser({
-    photos: photoBrowserPhotos
+    photos: photoBrowserPhotos,
 });
 var photoBrowserPopup = myApp.photoBrowser({
     photos: photoBrowserPhotos,
-    type: 'popup'
+    type: 'popup',
 });
 var photoBrowserPage = myApp.photoBrowser({
     photos: photoBrowserPhotos,
     type: 'page',
-    backLinkText: 'Back'
+    backLinkText: 'Back',
 });
 var photoBrowserDark = myApp.photoBrowser({
     photos: photoBrowserPhotos,
-    theme: 'dark'
+    theme: 'dark',
 });
 var photoBrowserPopupDark = myApp.photoBrowser({
     photos: photoBrowserPhotos,
     theme: 'dark',
-    type: 'popup'
+    type: 'popup',
 });
 var photoBrowserLazy = myApp.photoBrowser({
     photos: photoBrowserPhotos,
     lazyLoading: true,
-    theme: 'dark'
+    theme: 'dark',
 });
 myApp.onPageInit('photo-browser', function (page) {
     $$('.ks-pb-standalone').on('click', function () {

--- a/kitchen-sink/js/kitchen-sink.js
+++ b/kitchen-sink/js/kitchen-sink.js
@@ -290,29 +290,35 @@ var photoBrowserPhotos = [
 ];
 var photoBrowserStandalone = myApp.photoBrowser({
     photos: photoBrowserPhotos,
+    blurred: true
 });
 var photoBrowserPopup = myApp.photoBrowser({
     photos: photoBrowserPhotos,
     type: 'popup',
+    blurred: true
 });
 var photoBrowserPage = myApp.photoBrowser({
     photos: photoBrowserPhotos,
     type: 'page',
     backLinkText: 'Back',
+    blurred: true
 });
 var photoBrowserDark = myApp.photoBrowser({
     photos: photoBrowserPhotos,
     theme: 'dark',
+    blurred: true
 });
 var photoBrowserPopupDark = myApp.photoBrowser({
     photos: photoBrowserPhotos,
     theme: 'dark',
     type: 'popup',
+    blurred: true
 });
 var photoBrowserLazy = myApp.photoBrowser({
     photos: photoBrowserPhotos,
     lazyLoading: true,
     theme: 'dark',
+    blurred: true
 });
 myApp.onPageInit('photo-browser', function (page) {
     $$('.ks-pb-standalone').on('click', function () {

--- a/kitchen-sink/photo-browser.html
+++ b/kitchen-sink/photo-browser.html
@@ -1,5 +1,5 @@
 
-<div class="navbar">
+<div class="navbar blurred">
   <div class="navbar-inner">
     <div class="left sliding"><a href="index.html" class="back link"><i class="icon icon-back"></i><span>Back</span></a></div>
     <div class="center sliding">Photo Browser</div>

--- a/src/js/photo-browser.js
+++ b/src/js/photo-browser.js
@@ -25,6 +25,7 @@ var PhotoBrowser = function (params) {
         lazyLoading: false,
         lazyLoadingInPrevNext: false,
         lazyLoadingOnTransitionStart: false,
+        blurred: false,
         /*
         Callbacks:
         onLazyImageLoad(pb, slide, img)
@@ -41,7 +42,7 @@ var PhotoBrowser = function (params) {
         onSwipeToClose(pb)
         */
     };
-    
+
     params = params || {};
     for (var def in defaults) {
         if (typeof params[def] === 'undefined') {
@@ -50,10 +51,12 @@ var PhotoBrowser = function (params) {
     }
 
     pb.params = params;
-    
+
     var iconColor = pb.params.theme === 'dark' ? 'color-white' : '';
+    var blurred = pb.params.blurred ? 'blurred' : '';
 
     var navbarTemplate = pb.params.navbarTemplate ||
+                        '<div class="navbar '+ blurred + '">' +
                             '<div class="navbar-inner">' +
                                 '<div class="left sliding"><a href="#" class="link ' + (pb.params.type === 'page' && 'back') + ' close-popup photo-browser-close-link" data-popup=".photo-browser-popup"><i class="icon icon-back ' + iconColor + '"></i><span>' + pb.params.backLinkText + '</span></a></div>' +
                                 '<div class="center sliding"><span class="photo-browser-current"></span> <span class="photo-browser-of">' + pb.params.ofText + '</span> <span class="photo-browser-total"></span></div>' +
@@ -61,6 +64,7 @@ var PhotoBrowser = function (params) {
                             '</div>' +
                         '</div>';
     var toolbarTemplate = pb.params.toolbarTemplate ||
+                        '<div class="toolbar '+ blurred + ' tabbar">' +
                             '<div class="toolbar-inner">' +
                                 '<a href="#" class="link photo-browser-prev"><i class="icon icon-prev ' + iconColor + '"></i></a>' +
                                 '<a href="#" class="link photo-browser-next"><i class="icon icon-next ' + iconColor + '"></i></a>' +
@@ -98,7 +102,7 @@ var PhotoBrowser = function (params) {
         var photo = pb.params.photos[i];
         var thisTemplate = '';
 
-        //check if photo is a string or string-like object, for backwards compatibility 
+        //check if photo is a string or string-like object, for backwards compatibility
         if (typeof(photo) === 'string' || photo instanceof String) {
 
             //check if "photo" is html object
@@ -226,7 +230,7 @@ var PhotoBrowser = function (params) {
         pb.container.find('.photo-browser-total').text(total);
 
         $('.photo-browser-prev, .photo-browser-next').removeClass('photo-browser-link-inactive');
-        
+
         if (swiper.isBeginning && !pb.params.loop) {
             $('.photo-browser-prev').addClass('photo-browser-link-inactive');
         }
@@ -260,7 +264,7 @@ var PhotoBrowser = function (params) {
         }
         if (pb.params.onTransitionEnd) pb.params.onTransitionEnd(swiper);
     };
-    
+
     pb.layout = function (index) {
         if (pb.params.type === 'page') {
             pb.container = $('.photo-browser-swiper-container').parents('.view');
@@ -277,7 +281,7 @@ var PhotoBrowser = function (params) {
         pb.slides = pb.container.find('.photo-browser-slide');
         pb.captionsContainer = pb.container.find('.photo-browser-captions');
         pb.captions = pb.container.find('.photo-browser-caption');
-        
+
         var sliderSettings = {
             nextButton: pb.params.nextButton || '.photo-browser-next',
             prevButton: pb.params.prevButton || '.photo-browser-prev',
@@ -305,7 +309,7 @@ var PhotoBrowser = function (params) {
                 pb.onSliderTransitionStart(swiper);
             },
             onTransitionEnd: function (swiper) {
-                pb.onSliderTransitionEnd(swiper);  
+                pb.onSliderTransitionEnd(swiper);
             },
             onSlideChangeStart: pb.params.onSlideChangeStart,
             onSlideChangeEnd: pb.params.onSlideChangeEnd,
@@ -369,7 +373,7 @@ var PhotoBrowser = function (params) {
         if (pb.params.expositionHideCaptions) pb.captionsContainer.removeClass('photo-browser-captions-exposed');
         pb.exposed = false;
     };
-    
+
     // Gestures
     var gestureSlide, gestureImg, gestureImgWrap, scale = 1, currentScale = 1, isScaling = false;
     pb.onSlideGestureStart = function (e) {
@@ -456,7 +460,7 @@ var PhotoBrowser = function (params) {
         imageMaxX = -imageMinX;
         imageMinY = Math.min((pb.swiper.height / 2 - scaledHeight / 2), 0);
         imageMaxY = -imageMinY;
-        
+
         imageTouchesCurrent.x = e.type === 'touchmove' ? e.targetTouches[0].pageX : e.pageX;
         imageTouchesCurrent.y = e.type === 'touchmove' ? e.targetTouches[0].pageY : e.pageY;
 
@@ -474,14 +478,14 @@ var PhotoBrowser = function (params) {
         imageIsMoved = true;
         imageCurrentX = imageTouchesCurrent.x - imageTouchesStart.x + imageStartX;
         imageCurrentY = imageTouchesCurrent.y - imageTouchesStart.y + imageStartY;
-        
+
         if (imageCurrentX < imageMinX) {
             imageCurrentX =  imageMinX + 1 - Math.pow((imageMinX - imageCurrentX + 1), 0.8);
         }
         if (imageCurrentX > imageMaxX) {
             imageCurrentX = imageMaxX - 1 + Math.pow((imageCurrentX - imageMaxX + 1), 0.8);
         }
-        
+
         if (imageCurrentY < imageMinY) {
             imageCurrentY =  imageMinY + 1 - Math.pow((imageMinY - imageCurrentY + 1), 0.8);
         }

--- a/src/js/photo-browser.js
+++ b/src/js/photo-browser.js
@@ -54,7 +54,6 @@ var PhotoBrowser = function (params) {
     var iconColor = pb.params.theme === 'dark' ? 'color-white' : '';
 
     var navbarTemplate = pb.params.navbarTemplate ||
-                        '<div class="navbar">' +
                             '<div class="navbar-inner">' +
                                 '<div class="left sliding"><a href="#" class="link ' + (pb.params.type === 'page' && 'back') + ' close-popup photo-browser-close-link" data-popup=".photo-browser-popup"><i class="icon icon-back ' + iconColor + '"></i><span>' + pb.params.backLinkText + '</span></a></div>' +
                                 '<div class="center sliding"><span class="photo-browser-current"></span> <span class="photo-browser-of">' + pb.params.ofText + '</span> <span class="photo-browser-total"></span></div>' +
@@ -62,7 +61,6 @@ var PhotoBrowser = function (params) {
                             '</div>' +
                         '</div>';
     var toolbarTemplate = pb.params.toolbarTemplate ||
-                        '<div class="toolbar tabbar">' +
                             '<div class="toolbar-inner">' +
                                 '<a href="#" class="link photo-browser-prev"><i class="icon icon-prev ' + iconColor + '"></i></a>' +
                                 '<a href="#" class="link photo-browser-next"><i class="icon icon-next ' + iconColor + '"></i></a>' +
@@ -85,8 +83,8 @@ var PhotoBrowser = function (params) {
                         '</div>' +
                     '</div>';
 
-    var photoTemplate = !pb.params.lazyLoading ? 
-        (pb.params.photoTemplate || '<div class="photo-browser-slide swiper-slide"><span class="photo-browser-zoom-container"><img src="{{url}}"></span></div>') : 
+    var photoTemplate = !pb.params.lazyLoading ?
+        (pb.params.photoTemplate || '<div class="photo-browser-slide swiper-slide"><span class="photo-browser-zoom-container"><img src="{{url}}"></span></div>') :
         (pb.params.photoLazyTemplate || '<div class="photo-browser-slide photo-browser-slide-lazy swiper-slide"><div class="preloader' + (pb.params.theme === 'dark' ? ' preloader-white' : '') + '"></div><span class="photo-browser-zoom-container"><img data-src="{{url}}" class="swiper-lazy"></span></div>');
 
     var captionsTheme = pb.params.captionsTheme || pb.params.theme;

--- a/src/less/toolbars.less
+++ b/src/less/toolbars.less
@@ -40,6 +40,12 @@
     z-index: 500;
     -webkit-backface-visibility: hidden;
     backface-visibility: hidden;
+
+    &.blured {
+      -webkit-backdrop-filter: blur(8px);
+      background: rgba(255,255,255,0.6);
+    }
+
     b {
         font-weight: 500;
     }

--- a/src/less/toolbars.less
+++ b/src/less/toolbars.less
@@ -41,7 +41,7 @@
     -webkit-backface-visibility: hidden;
     backface-visibility: hidden;
 
-    &.blured {
+    &.blurred {
       -webkit-backdrop-filter: blur(8px);
       background: rgba(255,255,255,0.6);
     }


### PR DESCRIPTION
In the iOS9/Safari9 it will be possible to have the blurred look introduced in iOS7 using `-webkit-backdrop-filter`. 
This PR will add basic support for this in the `.navbar` and `.toolbar`. I also modified photoBrowser.js to support a `blurred` option. The kitchen-sink demo is updated accordingly. 

[Here](https://www.youtube.com/watch?v=54MT0fSWO7w) is how it looks on an iPad running iOS9 
