### PR TITLE
Fix an issue in router._back function

### DIFF
--- a/src/js/router.js
+++ b/src/js/router.js
@@ -934,7 +934,7 @@ app.router._back = function (view, options) {
         }
     }
     else {
-        if (url && url === view.url || pageName && view.activePage && view.activePage.name === pageName) {
+        if ((url && url === view.url || pageName && view.activePage && view.activePage.name === pageName) && !view.params.allowDuplicateUrls) {
             view.allowPageChange = true;
             return;
         }


### PR DESCRIPTION
Fixes #861.
Add conditional `&& !view.params.allowDuplicateUrls` when force==true and the url or pagename is the same.
In this way, the condition follow the same criteria used in router.load function, line 592.
