### PR TITLE
fix picker selecting incorrect item on scroll up

### DIFF
--- a/src/js/framework7/picker.js
+++ b/src/js/framework7/picker.js
@@ -341,7 +341,7 @@ var Picker = function (params) {
             newTranslate = Math.max(Math.min(newTranslate, maxTranslate), minTranslate);
 
             // Active Index
-            var activeIndex = -Math.floor((newTranslate - maxTranslate)/itemHeight);
+            var activeIndex = -Math.round((newTranslate - maxTranslate)/itemHeight);
 
             // Normalize translate
             if (!p.params.freeMode) newTranslate = -activeIndex * itemHeight + maxTranslate;


### PR DESCRIPTION
We are noticing that when we scroll up in the picker, and we scroll between two times, then the new time is selected, but when you remove your fingers then the the picker selects the old time, and not the new time. 

[Gif of bug](https://gyazo.com/399d3be580bbd7a40baad0a1a654b029)