### PR TITLE
[v2] minor fixes

### DIFF
--- a/scripts/build-js.js
+++ b/scripts/build-js.js
@@ -23,6 +23,16 @@ const banner = require('./banner.js');
 
 let cache;
 
+const external = [
+  'dom7',
+  'template7'
+]
+
+const globals = {
+  'template7': 'Template7',
+  'dom7': '$'
+}
+
 // Overwrite with local config
 try {
   const customConfig = require('./build-config-custom.js');
@@ -54,6 +64,8 @@ function es(components, cb) {
     name: 'Framework7',
     strict: true,
     sourcemap: false,
+    external,
+    globals,
     banner,
   })
     .on('error', (err) => {
@@ -86,6 +98,8 @@ function es(components, cb) {
     name: 'Framework7',
     strict: true,
     sourcemap: false,
+    external,
+    globals,
     banner,
   })
     .on('error', (err) => {
@@ -124,6 +138,8 @@ function umd(components, cb) {
     name: 'Framework7',
     strict: true,
     sourcemap: env === 'development',
+    external,
+    globals,
     banner,
     cache,
   })

--- a/src/modules/router/router-class.js
+++ b/src/modules/router/router-class.js
@@ -929,7 +929,7 @@ class Router extends Framework7Class {
         documentUrl = documentUrl.split(router.params.pushStateRoot)[1];
         if (documentUrl === '') documentUrl = '/';
       }
-      if (documentUrl.indexOf(router.params.pushStateSeparator) >= 0) {
+      if (router.params.pushStateSeparator.length > 0 && documentUrl.indexOf(router.params.pushStateSeparator) >= 0) {
         initUrl = documentUrl.split(router.params.pushStateSeparator)[1];
       } else {
         initUrl = documentUrl;


### PR DESCRIPTION
Hi. This PR fixes rollup build warning messages by explicitly define external and globals for `dom7` and `template7`. 

Also in order make empty `pushStateSeperator` support, we need an extra check to make sure not split `documentUrl` using empty string which makes `initUrl` undefined and cusing errors. This change has been tested to working with latest f7-vue commit.