### PR TITLE
[v2] fix: assign swiper on initSwipers

### DIFF
--- a/src/components/swiper/swiper.js
+++ b/src/components/swiper/swiper.js
@@ -56,7 +56,7 @@ function initSwipers(swiperEl) {
     });
   }
 
-  $swiperEl[0].swiper = app.swiper.create($swiperEl[0], params);
+  app.swiper.create($swiperEl[0], params);
 }
 
 export default {

--- a/src/components/swiper/swiper.js
+++ b/src/components/swiper/swiper.js
@@ -56,7 +56,7 @@ function initSwipers(swiperEl) {
     });
   }
 
-  app.swiper.create($swiperEl[0], params);
+  $swiperEl[0].swiper = app.swiper.create($swiperEl[0], params);
 }
 
 export default {

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -66,7 +66,7 @@ const Tab = {
     // Swipeable tabs
     if ($tabsEl.parent().hasClass('tabs-swipeable-wrap') && app.swiper) {
       const swiper = $tabsEl.parent()[0].swiper;
-      if (swiper.activeIndex !== $newTabEl.index()) {
+      if (swiper && swiper.activeIndex !== $newTabEl.index()) {
         swiper.slideTo($newTabEl.index(), animate ? undefined : 0, false);
       }
     }


### PR DESCRIPTION
This PR fixes problems with swipeable tabs which need `.swiper` reference.  ([here](https://github.com/framework7io/Framework7/blob/v2/src/components/tabs/tabs.js#L68)) Also, `swiper` existence is ensured to prevent any uncaught errors.