### PR TITLE
refactor: bring component prior to name when loading route

### DIFF
--- a/src/modules/router/back.js
+++ b/src/modules/router/back.js
@@ -464,7 +464,7 @@ function back(...args) {
     });
   }
 
-  ('url content name el component componentUrl template templateUrl').split(' ').forEach((pageLoadProp) => {
+  ('url content component name el componentUrl template templateUrl').split(' ').forEach((pageLoadProp) => {
     if (route.route[pageLoadProp]) {
       router.loadBack({ [pageLoadProp]: route.route[pageLoadProp] }, options);
     }

--- a/src/modules/router/navigate.js
+++ b/src/modules/router/navigate.js
@@ -461,7 +461,7 @@ function navigate(url, navigateOptions = {}) {
       router.modalLoad(modalLoadProp, route, options);
     }
   });
-  ('url content name el component componentUrl template templateUrl').split(' ').forEach((pageLoadProp) => {
+  ('url content component name el componentUrl template templateUrl').split(' ').forEach((pageLoadProp) => {
     if (route.route[pageLoadProp]) {
       router.load({ [pageLoadProp]: route.route[pageLoadProp] }, options);
     }


### PR DESCRIPTION
When using [nuxt7](https://github.com/pi0/nuxt7) which is based on [Framework7-Vue V2](https://github.com/framework7io/Framework7-vue), will get error with ios theme.

Because we defined `name` on every `routes` for some further use and [navigate](https://github.com/framework7io/Framework7/blob/v2/src/modules/router/navigate.js#L464-L468) will take take precedence over `component` and not call `pageComponentLoader`, so codes inside `forward` method will throw error due to empty component html.

The original bug description is in https://github.com/pi0/nuxt7/pull/8. Pls feel free to discuss with me to figure out a appropriate solution.