### PR TITLE
Add data-table to list of available custom modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ After that you will find created `custom/` folder with generated JS and CSS file
 * calendar
 * notifications
 * timeline
+* data-table
 
 ## Contributing
 

--- a/modules.json
+++ b/modules.json
@@ -255,5 +255,13 @@
             "material": ["src/less/material/timeline.less"]
         },
         "dependencies" : []
+    },
+    "data-table": {
+        "js" : ["src/js/framework7/data-table.js"],
+        "less": {
+            "ios": ["src/less/ios/data-table.less"],
+            "material": ["src/less/material/data-table.less"]
+        },
+        "dependencies" : []
     }
 }


### PR DESCRIPTION
`data-table` component is not available in custom module list. This PR adds it.
