### PR TITLE
Target .tablet-auto siblings instead of .col-auto

### DIFF
--- a/src/less/ios/grid.less
+++ b/src/less/ios/grid.less
@@ -69,7 +69,7 @@
             .-((@i - 1));
         } .-;
         .--(@j: 1) when (@j < length(@cols)) {
-            .tablet-auto:nth-last-child(@{j}), .tablet-auto:nth-last-child(@{j}) ~ .col-auto {
+            .tablet-auto:nth-last-child(@{j}), .tablet-auto:nth-last-child(@{j}) ~ .tablet-auto {
                 @j-1: @j - 1;  
                 width: 100% / @j;
                 width: ~"-webkit-calc((100% - 15px*@{j-1}) / @{j})";   


### PR DESCRIPTION
The .tablet-auto class was applying each incremental :nth-last-child width respectively to .tablet-auto elements instead of consistently using the smallest :nth-last-child width.