### PR TITLE
Remove ios theme restriction for handling `no-navbar` and `no-toolbar` CSS classes. (#2184)

### DIFF
--- a/src/components/navbar/navbar.js
+++ b/src/components/navbar/navbar.js
@@ -270,7 +270,6 @@ export default {
     },
     pageBeforeIn(page) {
       const app = this;
-      if (app.theme !== 'ios') return;
       let $navbarEl;
       const view = page.$el.parents('.view')[0].f7View;
       const navbarInnerEl = app.navbar.getElByPage(page);

--- a/src/components/toolbar/toolbar.js
+++ b/src/components/toolbar/toolbar.js
@@ -147,7 +147,6 @@ export default {
     },
     pageBeforeIn(page) {
       const app = this;
-      if (app.theme !== 'ios') return;
       let $toolbarEl = page.$el.parents('.view').children('.toolbar');
       if ($toolbarEl.length === 0) {
         $toolbarEl = page.$el.find('.toolbar');


### PR DESCRIPTION
If there is no particular reason to not handle these classes in Material Design theme, I think theses two changes can't be harmful and fix #2184.