### PR TITLE
Update framework7.js

### DIFF
--- a/dist/js/framework7.js
+++ b/dist/js/framework7.js
@@ -6093,6 +6093,7 @@ function load(loadParams, loadOptions, ignorePageChange) {
     !(options.reloadCurrent || options.reloadPrevious) &&
     !router.params.allowDuplicateUrls
   ) {
+    router.allowPageChange = true;
     return false;
   }
 


### PR DESCRIPTION
Fixed the issue #2200

This fixed the unable to navigate/back problem when a page has been called twice with async function defined in route