### PR TITLE
Add a difference on "distance from side of screen for slide panels swipe" when the slide is open

### DIFF
--- a/src/components/panel/panel.js
+++ b/src/components/panel/panel.js
@@ -10,6 +10,7 @@ export default {
       rightBreakpoint: 0,
       swipe: undefined, // or 'left' or 'right' or 'both'
       swipeActiveArea: 0,
+      swipeActiveAreaSide: 0,
       swipeCloseOpposite: true,
       swipeOnlyClose: false,
       swipeNoFollow: false,

--- a/src/components/panel/swipe-panel.js
+++ b/src/components/panel/swipe-panel.js
@@ -53,10 +53,10 @@ function swipePanel(panel) {
       }
     }
     if (params.swipeActiveAreaSide && panel.opened) {
-		  if (side === 'right') {
-		    if (touchesStart.x > (app.width - $el.outerWidth() + params.swipeActiveAreaSide)) return;
-		  }
-	  }    
+      if (side === 'right') {
+        if (touchesStart.x > (app.width - panel.$el.outerWidth() + params.swipeActiveAreaSide)) return;
+      }
+    }    
     touchMoves = 0;
     $viewEl = $(panel.getViewEl());
     isMoved = false;

--- a/src/components/panel/swipe-panel.js
+++ b/src/components/panel/swipe-panel.js
@@ -54,7 +54,7 @@ function swipePanel(panel) {
     }
     if (params.swipeActiveAreaSide && panel.opened) {
       if (side === 'right') {
-        if (touchesStart.x > (app.width - ($el.outerWidth() + params.swipeActiveAreaSide))) return;
+        if (touchesStart.x > (app.width - $el.outerWidth() + params.swipeActiveAreaSide)) return;
       }
     }    
     touchMoves = 0;

--- a/src/components/panel/swipe-panel.js
+++ b/src/components/panel/swipe-panel.js
@@ -53,8 +53,11 @@ function swipePanel(panel) {
       }
     }
     if (params.swipeActiveAreaSide && panel.opened) {
+      if (side === 'left') {
+        if (touchesStart.x < ($el[0].offsetWidth - params.swipeActiveAreaSide)) return;
+      }
       if (side === 'right') {
-        if (touchesStart.x > ((app.width - $el.outerWidth()) + params.swipeActiveAreaSide)) return;
+        if (touchesStart.x > ((app.width - $el[0].offsetWidth) + params.swipeActiveAreaSide)) return;
       }
     }
     touchMoves = 0;

--- a/src/components/panel/swipe-panel.js
+++ b/src/components/panel/swipe-panel.js
@@ -52,6 +52,11 @@ function swipePanel(panel) {
         if (touchesStart.x < app.width - params.swipeActiveArea) return;
       }
     }
+    if (params.swipeActiveAreaSide && panel.opened) {
+		  if (side === 'right') {
+		    if (touchesStart.x > (app.width - $el.outerWidth() + params.swipeActiveAreaSide)) return;
+		  }
+	  }    
     touchMoves = 0;
     $viewEl = $(panel.getViewEl());
     isMoved = false;

--- a/src/components/panel/swipe-panel.js
+++ b/src/components/panel/swipe-panel.js
@@ -54,9 +54,9 @@ function swipePanel(panel) {
     }
     if (params.swipeActiveAreaSide && panel.opened) {
       if (side === 'right') {
-        if (touchesStart.x > (app.width - $el.outerWidth() + params.swipeActiveAreaSide)) return;
+        if (touchesStart.x > ((app.width - $el.outerWidth()) + params.swipeActiveAreaSide)) return;
       }
-    }    
+    }
     touchMoves = 0;
     $viewEl = $(panel.getViewEl());
     isMoved = false;

--- a/src/components/panel/swipe-panel.js
+++ b/src/components/panel/swipe-panel.js
@@ -54,7 +54,7 @@ function swipePanel(panel) {
     }
     if (params.swipeActiveAreaSide && panel.opened) {
       if (side === 'right') {
-        if (touchesStart.x > (app.width - panel.$el.outerWidth() + params.swipeActiveAreaSide)) return;
+        if (touchesStart.x > (app.width - ($el.outerWidth() + params.swipeActiveAreaSide))) return;
       }
     }    
     touchMoves = 0;


### PR DESCRIPTION
Hello,
I am in French so forgive me for my writing.

When you choose to open the panel on the right, there is the property "swipeActiveArea" which allows to define the distance from which we will be able to open the slide. It's very good.

But it misses the same thing when the panel is open on the right on the open area to tell from what distance I can close the panel.
This is important because when we have on the panel elements that we can "swipe to delete", it will close the panel.

If you want, I can make a video to show you.