### PR TITLE
Add capability to find old tab link with `data-route-tab-id` attribute…

### DIFF
--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -138,7 +138,13 @@ const Tab = {
       if ($oldTabEl && $oldTabEl.length > 0) {
         // Search by id
         const oldTabId = $oldTabEl.attr('id');
-        if (oldTabId) $oldTabLinkEl = $(`.tab-link[href="#${oldTabId}"]`);
+        if (oldTabId) {
+          $oldTabLinkEl = $(`.tab-link[href="#${oldTabId}"]`);
+          // Search by data-route-tab-id
+          if (!$oldTabLinkEl || ($oldTabLinkEl && $oldTabLinkEl.length === 0)) {
+            $oldTabLinkEl = $(`.tab-link[data-route-tab-id="${oldTabId}"]`);
+          }
+        }
         // Search by data-tab
         if (!$oldTabLinkEl || ($oldTabLinkEl && $oldTabLinkEl.length === 0)) {
           $('[data-tab]').each((index, tabLinkElement) => {


### PR DESCRIPTION
… when using `tabs-routable`.

This commit allow to strongly find and update old `tab-link-active` in `tab-routable` scenarios thanks to `data-route-tab-id` attribute, even outside next siblings which is the actual way:
https://github.com/framework7io/framework7/blob/704695fed1c5e2a12dec3df4cfdf4c31d4c192d2/src/components/tabs/tabs.js#L149

In other words this allow to put tab links outside the toolbar if we want and rely on the good link activation of this component in order to maintain coherence of all links, wherever they are.