### PR TITLE
Fix Problem with {{@index}} variable in virtual List

### DIFF
--- a/src/components/virtual-list/virtual-list-class.js
+++ b/src/components/virtual-list/virtual-list-class.js
@@ -238,7 +238,7 @@ class VirtualList extends Framework7Class {
         itemEl.f7VirtualListIndex = index;
       } else {
         if (vl.renderItem) {
-          vl.tempDomElement.innerHTML = vl.renderItem(items[i], index).trim();
+          vl.tempDomElement.innerHTML = vl.renderItem(items[i], {index: index}).trim();
         } else {
           vl.tempDomElement.innerHTML = items[i].toString().trim();
         }

--- a/src/components/virtual-list/virtual-list-class.js
+++ b/src/components/virtual-list/virtual-list-class.js
@@ -238,7 +238,7 @@ class VirtualList extends Framework7Class {
         itemEl.f7VirtualListIndex = index;
       } else {
         if (vl.renderItem) {
-          vl.tempDomElement.innerHTML = vl.renderItem(items[i], { 'index': index }).trim();
+          vl.tempDomElement.innerHTML = vl.renderItem(items[i], { index: index }).trim();
         } else {
           vl.tempDomElement.innerHTML = items[i].toString().trim();
         }

--- a/src/components/virtual-list/virtual-list-class.js
+++ b/src/components/virtual-list/virtual-list-class.js
@@ -238,7 +238,7 @@ class VirtualList extends Framework7Class {
         itemEl.f7VirtualListIndex = index;
       } else {
         if (vl.renderItem) {
-          vl.tempDomElement.innerHTML = vl.renderItem(items[i], { "index": index } ).trim();
+          vl.tempDomElement.innerHTML = vl.renderItem(items[i], { 'index': index }).trim();
         } else {
           vl.tempDomElement.innerHTML = items[i].toString().trim();
         }

--- a/src/components/virtual-list/virtual-list-class.js
+++ b/src/components/virtual-list/virtual-list-class.js
@@ -238,7 +238,7 @@ class VirtualList extends Framework7Class {
         itemEl.f7VirtualListIndex = index;
       } else {
         if (vl.renderItem) {
-          vl.tempDomElement.innerHTML = vl.renderItem(items[i], { index: index } ).trim();
+          vl.tempDomElement.innerHTML = vl.renderItem(items[i], { "index": index } ).trim();
         } else {
           vl.tempDomElement.innerHTML = items[i].toString().trim();
         }

--- a/src/components/virtual-list/virtual-list-class.js
+++ b/src/components/virtual-list/virtual-list-class.js
@@ -238,7 +238,7 @@ class VirtualList extends Framework7Class {
         itemEl.f7VirtualListIndex = index;
       } else {
         if (vl.renderItem) {
-          vl.tempDomElement.innerHTML = vl.renderItem(items[i], {index: index}).trim();
+          vl.tempDomElement.innerHTML = vl.renderItem(items[i], { index: index } ).trim();
         } else {
           vl.tempDomElement.innerHTML = items[i].toString().trim();
         }


### PR DESCRIPTION
Problem: by using {{@index}} template Variable in virtual-List only the first line in the virtual-List will use the line-index-variable, following lines will not receive the value of the line-Index. 

Fix a Problem with template-line-index {{@index}} variable in virtual List. 
In this line the used index-variable for a compiled template is in form 
{index: index-number} expected. 
In version 2.x of framework7 there is only a number Variable. 
Inside a compiled template the data access is done by
  c((data && data.index), ctx_1)
so the compiled template needs a Object with variable index.
Example Template with {{@index}} Variable to set SLOT DOM-Variable
> <li >
	<a href="#" class="item-link item-content" SLOT="{{@index}}">
		<div class="item-inner">
			<div class="item-title-row">
				<div class="item-title">{{OBJNAM}} </div>
			</div>
		</div>
	</a>
</li>

Result without fix 
first rendered line: 

> <li >
	<a href="#" class="item-link item-content" SLOT="0">
		<div class="item-inner">
			<div class="item-title-row">
				<div class="item-title">foo bar</div>
			</div>
		</div>
	</a>
</li>


following rendered lines:

> <li >
	<a href="#" class="item-link item-content" SLOT="">
		<div class="item-inner">
			<div class="item-title-row">
				<div class="item-title">..correct values..</div>
			</div>
		</div>
	</a>
</li>



