### PR TITLE
fixing the background color property for action sheet buttons

### DIFF
--- a/src/components/actions/actions-class.js
+++ b/src/components/actions/actions-class.js
@@ -195,7 +195,7 @@ class Actions extends Modal {
               const buttonClasses = [`actions-${button.label ? 'label' : 'button'}`];
               const { color, bg, bold, disabled, label, text, icon } = button;
               if (color) buttonClasses.push(`color-${color}`);
-              if (bg) buttonClasses.push(`bg-${color}`);
+              if (bg) buttonClasses.push(`bg-color-${bg}`);
               if (bold) buttonClasses.push('actions-button-bold');
               if (disabled) buttonClasses.push('disabled');
               if (label) {
@@ -225,7 +225,7 @@ class Actions extends Modal {
                   const itemClasses = [];
                   const { color, bg, bold, disabled, label, text, icon } = button;
                   if (color) itemClasses.push(`color-${color}`);
-                  if (bg) itemClasses.push(`bg-${bg}`);
+                  if (bg) itemClasses.push(`bg-color-${bg}`);
                   if (bold) itemClasses.push('popover-from-actions-bold');
                   if (disabled) itemClasses.push('disabled');
                   if (label) {


### PR DESCRIPTION
The background color wasn't being applied correctly due to the class name being incorrect. I changed the class name to include -color- to fix the issue. I also noticed that the non popover option for the action sheet was using the color variable instead of the bg variable. I changed it to use the bg variable just like the popover version of the action sheet does.

I thought it might help so I included screenshots below of the code before and after the changes.

Before:
![before](https://user-images.githubusercontent.com/7772649/36927865-d5bf8536-1e3d-11e8-9eea-f2ef7fb4d816.png)
![before-popover](https://user-images.githubusercontent.com/7772649/36927866-d7f4df5e-1e3d-11e8-8cd1-6c40dfffd59a.png)

After:
![after](https://user-images.githubusercontent.com/7772649/36927871-dd9d6200-1e3d-11e8-9856-419649d0ce6e.png)
![after-popover](https://user-images.githubusercontent.com/7772649/36927872-deb76cc6-1e3d-11e8-8a1e-2d1f5c622b6a.png)

Issue: https://github.com/framework7io/framework7/issues/2236
