### PR TITLE
add more accurate condition

### DIFF
--- a/src/components/modal/modal-class.js
+++ b/src/components/modal/modal-class.js
@@ -121,7 +121,7 @@ class Modal extends Framework7Class {
     function transitionEnd() {
       if ($el.hasClass('modal-out')) {
         modal.onClosed();
-      } else {
+      } else if ($el.hasClass('modal-in')) {
         modal.onOpened();
       }
     }
@@ -172,7 +172,7 @@ class Modal extends Framework7Class {
     function transitionEnd() {
       if ($el.hasClass('modal-out')) {
         modal.onClosed();
-      } else {
+      } else if ($el.hasClass('modal-in')) {
         modal.onOpened();
       }
     }


### PR DESCRIPTION
In some special scene, when the `modal` closed, and  class `modal-out` also removed, then event `transitionEnd` may also be fired, which will invoke `modal.onOpened()`.