### PR TITLE
Defining componentUrl methods in routes

### DIFF
--- a/src/modules/router/router-class.js
+++ b/src/modules/router/router-class.js
@@ -822,6 +822,7 @@ class Router extends Framework7Class {
           },
         }
       );
+      c.methods = Utils.merge({}, c.methods, options.methods); //defining componentUrl methods in routes
       const createdComponent = Component.create(c, extendContext);
       resolve(createdComponent.el);
     }


### PR DESCRIPTION
When using external router component files (using parameter **componentUrl**), component methods must be defined inside the component html file. Sometimes it may be preferable to define these methods in external js files, or in routes.js, so html file only left with template and style.

A work-around is to define the function methods in context, but they do not bind to component instance.

Propose to update componentLoader to merge the methods defined in routes.js with those defined in html file.

So routes could be like this:

`routes: [
{
path : '/path/,
componentUrl: '/pah/to/component/htmlfile',
on: {
},
methods: {
'method1: function
}
}
]`