### PR TITLE
fix the searchbar input-clear-button without right margin in v2.1.2

### DIFF
--- a/src/components/searchbar/searchbar-ios.less
+++ b/src/components/searchbar/searchbar-ios.less
@@ -31,6 +31,7 @@
     }
     .input-clear-button {
       z-index: 40;
+      right: 7px;
     }
   }
   .searchbar-expandable {


### PR DESCRIPTION
fix the input-clear-button without right margin in v2.1.2