### PR TITLE
Fix flickering when page content is scrollable

### DIFF
--- a/src/components/panel/panel.less
+++ b/src/components/panel/panel.less
@@ -56,13 +56,6 @@
     z-index: 5900;
   }
 }
-html.with-panel {
-  .framework7-root > .views, .framework7-root > .view {
-    .page-content {
-      .not-scrollable();
-    }
-  }
-}
 html.with-panel-left-cover, html.with-panel-right-cover {
   .panel-backdrop {
     display: block;


### PR DESCRIPTION
Screen flickering while opening panel with page content is scrollable in iOS PhoneGap environment
Fixed #2293