### PR TITLE
Fix flickering when page content is scrollable

### DIFF
--- a/src/components/popup/popup.less
+++ b/src/components/popup/popup.less
@@ -87,15 +87,6 @@ html.with-statusbar {
     }
   }
 }
-html.with-modal-popup {
-  .framework7-root {
-    > .views, > .view, > .panel {
-      .page-content {
-        .not-scrollable();
-      }
-    }
-  }
-}
 & when (@includeIosTheme) {
   @import url('./popup-ios.less');
 }


### PR DESCRIPTION
Screen flickering while opening popup with page content is scrollable in iOS PhoneGap environment

Fixed #2293 