### PR TITLE
Fix mobile Safari ignoring last non-alphabet after composition end

### DIFF
--- a/src/components/autocomplete/autocomplete-class.js
+++ b/src/components/autocomplete/autocomplete-class.js
@@ -232,7 +232,7 @@ class Autocomplete extends Framework7Class {
       }
       if (ac.params.openIn === 'dropdown' && ac.$inputEl) {
         ac.$inputEl.on('focus', onInputFocus);
-        ac.$inputEl.on('input', onInputChange);
+        ac.$inputEl.on('change keyup compositionend', onInputChange);
         if (app.device.android) {
           $('html').on('click', onHtmlClick);
         } else {
@@ -249,7 +249,7 @@ class Autocomplete extends Framework7Class {
       }
       if (ac.params.openIn === 'dropdown' && ac.$inputEl) {
         ac.$inputEl.off('focus', onInputFocus);
-        ac.$inputEl.off('input', onInputChange);
+        ac.$inputEl.off('change keyup compositionend', onInputChange);
         if (app.device.android) {
           $('html').off('click', onHtmlClick);
         } else {

--- a/src/components/autocomplete/autocomplete-class.js
+++ b/src/components/autocomplete/autocomplete-class.js
@@ -232,7 +232,7 @@ class Autocomplete extends Framework7Class {
       }
       if (ac.params.openIn === 'dropdown' && ac.$inputEl) {
         ac.$inputEl.on('focus', onInputFocus);
-        ac.$inputEl.on('input', function() { setTimeout( onInputChange, 0)});
+        ac.$inputEl.on('input', function() { setTimeout(onInputChange, 0); });
         if (app.device.android) {
           $('html').on('click', onHtmlClick);
         } else {

--- a/src/components/autocomplete/autocomplete-class.js
+++ b/src/components/autocomplete/autocomplete-class.js
@@ -232,7 +232,7 @@ class Autocomplete extends Framework7Class {
       }
       if (ac.params.openIn === 'dropdown' && ac.$inputEl) {
         ac.$inputEl.on('focus', onInputFocus);
-        ac.$inputEl.on('input', function() { setTimeout(onInputChange, 0); });
+        ac.$inputEl.on('input', function () { setTimeout(onInputChange, 0); });
         if (app.device.android) {
           $('html').on('click', onHtmlClick);
         } else {

--- a/src/components/autocomplete/autocomplete-class.js
+++ b/src/components/autocomplete/autocomplete-class.js
@@ -249,7 +249,7 @@ class Autocomplete extends Framework7Class {
       }
       if (ac.params.openIn === 'dropdown' && ac.$inputEl) {
         ac.$inputEl.off('focus', onInputFocus);
-        ac.$inputEl.off('change keyup compositionend', onInputChange);
+        ac.$inputEl.off('input', onInputChange);
         if (app.device.android) {
           $('html').off('click', onHtmlClick);
         } else {

--- a/src/components/autocomplete/autocomplete-class.js
+++ b/src/components/autocomplete/autocomplete-class.js
@@ -232,7 +232,7 @@ class Autocomplete extends Framework7Class {
       }
       if (ac.params.openIn === 'dropdown' && ac.$inputEl) {
         ac.$inputEl.on('focus', onInputFocus);
-        ac.$inputEl.on('change keyup compositionend', onInputChange);
+        ac.$inputEl.on('input', function() { setTimeout( onInputChange, 0)});
         if (app.device.android) {
           $('html').on('click', onHtmlClick);
         } else {


### PR DESCRIPTION
This fixed the buggy "input" event in iOS safari, which ignore the last non-alphabet (e.g. Chinese) character after composition end.
