### PR TITLE
Support non string className (SVGAnimatedString)

### DIFF
--- a/src/components/swipeout/swipeout.js
+++ b/src/components/swipeout/swipeout.js
@@ -330,7 +330,7 @@ const Swipeout = {
           $(Swipeout.el).is($targetEl[0]) ||
           $targetEl.parents('.swipeout').is(Swipeout.el) ||
           $targetEl.hasClass('modal-in') ||
-          $targetEl[0].className.indexOf('-backdrop') > 0 ||
+          ($targetEl.attr('class') || '').indexOf('-backdrop') > 0 ||
           $targetEl.hasClass('actions-modal') ||
           $targetEl.parents('.actions-modal.modal-in, .dialog.modal-in').length > 0
         )) {


### PR DESCRIPTION
The following error occurs when swipeout item is opened and an outside SVG element is cliked
```
Uncaught TypeError: $targetEl[0].className.indexOf is not a function
```
It appears that $targetEl[0].className is an instance of [SVGAnimatedString](https://developer.mozilla.org/en-US/docs/Web/API/SVGAnimatedString) when clicked on an SVG element. 

as a workaround I do the following, which is not a standard practice in a long run:

```javascript
   SVGAnimatedString.prototype.indexOf = function(){
     return this.baseVal.indexOf.apply(this.baseVal, arguments)
   }
```

getting the attribute directly without the `className` property supports both html elements and svg elements.