### PR TITLE
Add ptr support for pages with subnavbar/toolbar

### DIFF
--- a/src/components/pull-to-refresh/pull-to-refresh-md.less
+++ b/src/components/pull-to-refresh/pull-to-refresh-md.less
@@ -1,9 +1,11 @@
 .md {
   @import (multiple) '../../less/colors-md.less';
+  @ptrTop: 66px - 50px;
+  @ptrTopTablet: 64px - 40px;
   .ptr-preloader {
     position: absolute;
     left: 50%;
-    top: 66px - 50px;
+    top: @ptrTop;
     width: 40px;
     height: 40px;
     border-radius: 50%;
@@ -13,7 +15,7 @@
     z-index: 100;
     .md-depth(1);
     @media (min-width:768px) {
-      top: 64px - 40px;
+      top: @ptrTopTablet;
     }
     .preloader {
       width: 22px;
@@ -101,4 +103,12 @@
       margin-bottom: 7px;
     }
   }
+	.page-with-subnavbar, .toolbar:not(.toolbar-bottom-md) ~ .ptr-content {
+	    .ptr-preloader {
+	    	top: @ptrTop + 48px;
+        @media (min-width:768px) {
+          top: @ptrTopTablet + 48px;
+        }
+	    }
+	}
 }


### PR DESCRIPTION
On material theme, when you have a subnavbar or toolbar/tabbar along with pull to refresh, the preloader hides behind the subnavbar or toolbar.

This pull request fixes that issue.