### PR TITLE
fix the error msg when success callback has error

### DIFF
--- a/src/js/dom7/dom7.js
+++ b/src/js/dom7/dom7.js
@@ -1875,7 +1875,7 @@ function ajax(options) {
           responseData = JSON.parse(xhr.responseText);
           fireAjaxCallback('ajaxSuccess ajax:success', { xhr: xhr }, 'success', responseData, xhr.status, xhr);
         } catch (err) {
-          fireAjaxCallback('ajaxError ajax:error', { xhr: xhr, parseerror: true }, 'error', xhr, 'parseerror');
+          fireAjaxCallback('ajaxError ajax:error', { xhr: xhr, error: true }, 'error', xhr, err.message);
         }
       } else {
         responseData = xhr.responseType === 'text' || xhr.responseType === '' ? xhr.responseText : xhr.response;


### PR DESCRIPTION
// test case
// assume test.php return valid json format
```javascript
$.post('test.php', {}, function (data) {
	throw Error('callback error');
}, function (xhr, msg) {
	alert(msg);
}, 'json');
```