### PR TITLE
Removing useless code from `grid`'s less files

### DIFF
--- a/dist/components/grid/grid-ios.less
+++ b/dist/components/grid/grid-ios.less
@@ -22,8 +22,6 @@
     .-;
 
     .--(@j: 1) when (@j < length(@cols)) {
-      @divider: e(extract(@cols, @j));
-      @className: `Math.floor(@{divider})`;
       .col:nth-last-child(@{j}), .col:nth-last-child(@{j}) ~ .col {
         @j-1: @j - 1;
         width: 100% / @j;

--- a/dist/components/grid/grid-md.less
+++ b/dist/components/grid/grid-md.less
@@ -22,8 +22,6 @@
     .-;
 
     .--(@j: 1) when (@j < length(@cols)) {
-      @divider: e(extract(@cols, @j));
-      @className: `Math.floor(@{divider})`;
       .col:nth-last-child(@{j}), .col:nth-last-child(@{j}) ~ .col {
         @j-1: @j - 1;
         width: 100% / @j;


### PR DESCRIPTION
these codes are not used and also cause error when `grid.less` is imported
