### PR TITLE
Fix lock-threads config

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,5 +1,3 @@
-daysUntilStale: 90
-daysUntilClose: 7
 exemptLabels:
   - Feature Request
   - Enhancement


### PR DESCRIPTION
Spotted with Sentry.

```js
Error: ValidationError: "daysUntilStale" is not allowed. "daysUntilClose" is not allowed
```