### PR TITLE
Use default behavior to open external link

### DIFF
--- a/src/modules/clicks/clicks.js
+++ b/src/modules/clicks/clicks.js
@@ -21,7 +21,6 @@ function initClicks(app) {
           if (target !== '_browser' && window.cordova && window.cordova.InAppBrowser) {
             e.preventDefault();
             window.cordova.InAppBrowser.open(url, target);
-          } else {
           }
         }
         return;

--- a/src/modules/clicks/clicks.js
+++ b/src/modules/clicks/clicks.js
@@ -18,11 +18,10 @@ function initClicks(app) {
       if (clickedLink.is(app.params.clicks.externalLinks) || (url && url.indexOf('javascript:') >= 0)) {
         const target = clickedLink.attr('target');
         if (url && (target === '_system' || target === '_blank' || target === '_browser')) {
-          e.preventDefault();
           if (target !== '_browser' && window.cordova && window.cordova.InAppBrowser) {
+            e.preventDefault();
             window.cordova.InAppBrowser.open(url, target);
           } else {
-            window.open(url, target);
           }
         }
         return;


### PR DESCRIPTION
Use default behavior to open external link

Why not `window.open`? Because some browsers block it

If we know it is just a simple normal external link, why not just open it using the default behavior?