### PR TITLE
Fix issue #1546 calendar / datepicker: firstDay:6 causes first week o…

### DIFF
--- a/src/js/framework7/calendar.js
+++ b/src/js/framework7/calendar.js
@@ -451,7 +451,7 @@ var Calendar = function (params) {
         var dayDate, currentValues = [], i, j, k,
             rows = 6, cols = 7,
             monthHTML = '',
-            dayIndex = 0 + (p.params.firstDay - 1),
+            dayIndex = 0 + ((p.params.firstDay - 8) % 7),
             today = new Date().setHours(0,0,0,0),
             minDate = p.params.minDate ? new Date(p.params.minDate).getTime() : null,
             maxDate = p.params.maxDate ? new Date(p.params.maxDate).getTime() : null,


### PR DESCRIPTION
First day         Before patch          After patch
7                      6                              -1
6                      5                              -2
5                      4                              -3
4                      3                              -4
3                      2                              -5
2                      1                               -6
1                       0                              0
0                       -1                             -1