### PR TITLE
specify more precisely which popup to close

### DIFF
--- a/src/core/components/smart-select/smart-select-class.js
+++ b/src/core/components/smart-select/smart-select-class.js
@@ -336,7 +336,7 @@ class SmartSelect extends Framework7Class {
             <div class="navbar${ss.params.navbarColorTheme ? `theme-${ss.params.navbarColorTheme}` : ''}">
               <div class="navbar-inner sliding">
                 <div class="left">
-                  <a href="#" class="link popup-close">
+                  <a href="#" class="link popup-close" data-popup=".smart-select-popup[data-select-name='${ss.selectName}']">
                     <i class="icon icon-back"></i>
                     <span class="ios-only">${ss.params.popupCloseLinkText}</span>
                   </a>


### PR DESCRIPTION
If smartSelect is opened in a popup from other popup (sourcePopup), then clicking on close button in smartSelect popup header will cause the sourcePopup to be closed, while smartSelect popup remains opened.

I propose to more precisely set which popup to close in smartSelect renderPopup function