### PR TITLE
Add manual input with fractions to stepper

### DIFF
--- a/kitchen-sink/core/pages/stepper.html
+++ b/kitchen-sink/core/pages/stepper.html
@@ -506,7 +506,22 @@
           </li>
         </ul>
       </div>
-    </div>
+	  <div class="block-title">Manual input</div>
+      <div class="block-header">It is possible to enter value manually from keyboard or mobile keypad. When click on input field, stepper enter into manual input mode, which allow type value from keyboar and check fractional part with defined accurancy. Click outside or enter Return key, ending manual mode.</div>
+      <div class="block block-strong text-align-center">
+        <div class="row">
+          <div class="col">
+            <div class="stepper stepper-fill stepper-init" data-wraps="true" data-autorepeat="true" data-autorepeat-dynamic="true">
+              <div class="stepper-button-minus"></div>
+              <div class="stepper-input-wrap">
+                <input type="text" value="0" min="0" max="10" step="1" decimalPoint="2">
+              </div>
+              <div class="stepper-button-plus"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+	</div>
   </div>
 </template>
 <style scoped>

--- a/src/core/components/stepper/stepper-class.js
+++ b/src/core/components/stepper/stepper-class.js
@@ -51,7 +51,7 @@ class Stepper extends Framework7Class {
     }
 
     if ($inputEl && $inputEl.length) {
-      ('step min max').split(' ').forEach((paramName) => {
+      ('step min max decimalPoint').split(' ').forEach((paramName) => {
         if (!params[paramName] && $inputEl.attr(paramName)) {
           stepper.params[paramName] = parseFloat($inputEl.attr(paramName));
         }
@@ -225,6 +225,7 @@ class Stepper extends Framework7Class {
       stepper.endTypeMode();
     }
     function onInput(e) {
+      if (manualInput) { stepper.typeValue(e.target.value); return; }
       if (e.detail && e.detail.sentByF7Stepper) return;
       stepper.setValue(e.target.value, true);
     }
@@ -319,6 +320,7 @@ class Stepper extends Framework7Class {
   endTypeMode() {
     const stepper = this;
     stepper.value = parseFloat(stepper.value);
+	if (isNaN(stepper.value)) stepper.value = 0;
 
     stepper.$el.trigger('stepper:change', stepper, stepper.value);
     const formattedValue = stepper.formatValue(stepper.value);

--- a/src/core/components/stepper/stepper-class.js
+++ b/src/core/components/stepper/stepper-class.js
@@ -20,6 +20,8 @@ class Stepper extends Framework7Class {
       autorepeat: false,
       autorepeatDynamic: false,
       wraps: false,
+      decimalPoint: 4,
+	  buttonsEndInputMode: true,
     };
 
     // Extend defaults with modules params
@@ -54,6 +56,13 @@ class Stepper extends Framework7Class {
           stepper.params[paramName] = parseFloat($inputEl.attr(paramName));
         }
       });
+	  
+	  const decimalPoint = parseInt(stepper.params.decimalPoint);
+      if (Number.isNaN(decimalPoint)) {
+        stepper.params.decimalPoint = 0;
+      } else {
+        stepper.params.decimalPoint = decimalPoint;
+      }
 
       const inputValue = parseFloat($inputEl.val());
       if (typeof params.value === 'undefined' && !Number.isNaN(inputValue) && (inputValue || inputValue === 0)) {
@@ -71,7 +80,7 @@ class Stepper extends Framework7Class {
     const $buttonPlusEl = $el.find('.stepper-button-plus');
     const $buttonMinusEl = $el.find('.stepper-button-minus');
 
-    const { step, min, max, value } = stepper.params;
+    const { step, min, max, value, decimalPoint } = stepper.params;
 
     Utils.extend(stepper, {
       app,
@@ -88,7 +97,8 @@ class Stepper extends Framework7Class {
       step,
       min,
       max,
-      value,
+      value,      
+	  decimalPoint,
     });
 
     $el[0].f7Stepper = stepper;
@@ -101,7 +111,8 @@ class Stepper extends Framework7Class {
     let intervalId;
     let timeoutId;
     let autorepeatAction = null;
-    let autorepeatInAction = false;
+    let autorepeatInAction = false;    
+	let manualInput = false;
 
     function dynamicRepeat(current, progressions, startsIn, progressionStep, repeatEvery, action) {
       clearTimeout(timeoutId);
@@ -122,7 +133,8 @@ class Stepper extends Framework7Class {
     }
 
     function onTouchStart(e) {
-      if (isTouched) return;
+      if (isTouched) return;      
+	  if (manualInput) { return; }
       if ($(e.target).closest($buttonPlusEl).length) {
         autorepeatAction = 'increment';
       } else if ($(e.target).closest($buttonMinusEl).length) {
@@ -142,6 +154,7 @@ class Stepper extends Framework7Class {
     }
     function onTouchMove(e) {
       if (!isTouched) return;
+	  if (manualInput) { return; }
       const pageX = e.type === 'touchmove' ? e.targetTouches[0].pageX : e.pageX;
       const pageY = e.type === 'touchmove' ? e.targetTouches[0].pageY : e.pageY;
 
@@ -165,6 +178,13 @@ class Stepper extends Framework7Class {
     }
 
     function onMinusClick() {
+	  if (manualInput) {
+        if (stepper.params.buttonsEndInputMode) {
+          manualInput = false;
+          stepper.endTypeMode();
+        };
+        return;
+      }
       if (preventButtonClick) {
         preventButtonClick = false;
         return;
@@ -172,11 +192,37 @@ class Stepper extends Framework7Class {
       stepper.decrement();
     }
     function onPlusClick() {
+	  if (manualInput) {
+        if (stepper.params.buttonsEndInputMode) {
+          manualInput = false;
+          stepper.endTypeMode();
+        };
+        return;
+      }
       if (preventButtonClick) {
         preventButtonClick = false;
         return;
       }
       stepper.increment();
+    }
+    function onInputClick(e) {
+      if (!e.target.readOnly) {
+        manualInput = true;
+        if (typeof e.target.selectionStart == "number") {
+          e.target.selectionStart = e.target.selectionEnd = e.target.value.length;
+        }
+      }
+    }
+    function onInputKey(e) {
+      if (e.keyCode == 13 || e.which == 13) {
+        e.preventDefault();
+        manualInput = false;
+        stepper.endTypeMode();
+      }
+    }
+    function onInputBlur() {
+      manualInput = false;
+      stepper.endTypeMode();
     }
     function onInput(e) {
       if (e.detail && e.detail.sentByF7Stepper) return;
@@ -187,6 +233,9 @@ class Stepper extends Framework7Class {
       $buttonPlusEl.on('click', onPlusClick);
       if (stepper.params.watchInput && $inputEl && $inputEl.length) {
         $inputEl.on('input', onInput);
+        $inputEl.on('click', onInputClick);
+        $inputEl.on('blur', onInputBlur);
+        $inputEl.on('keyup', onInputKey);
       }
       if (stepper.params.autorepeat) {
         app.on('touchstart:passive', onTouchStart);
@@ -199,6 +248,9 @@ class Stepper extends Framework7Class {
       $buttonPlusEl.off('click', onPlusClick);
       if (stepper.params.watchInput && $inputEl && $inputEl.length) {
         $inputEl.off('input', onInput);
+        $inputEl.off('click', onInputClick);
+        $inputEl.off('blur', onInputBlur);
+        $inputEl.off('keyup', onInputKey);
       }
     };
 
@@ -263,6 +315,61 @@ class Stepper extends Framework7Class {
     stepper.emit('local::change stepperChange', stepper, stepper.value);
     return stepper;
   }
+
+  endTypeMode() {
+    const stepper = this;
+    stepper.value = parseFloat(stepper.value);
+
+    stepper.$el.trigger('stepper:change', stepper, stepper.value);
+    const formattedValue = stepper.formatValue(stepper.value);
+    if (stepper.$inputEl && stepper.$inputEl.length) {
+      stepper.$inputEl.val(formattedValue);
+      stepper.$inputEl.trigger('input change', { sentByF7Stepper: true });
+      stepper.$inputEl.blur();
+    }
+    if (stepper.$valueEl && stepper.$valueEl.length) {
+      stepper.$valueEl.html(formattedValue);
+    }
+    stepper.emit('local::change stepperChange', stepper, stepper.value);
+    return stepper;
+  };
+
+  typeValue(value) {
+    const stepper = this;
+    const { step, min, max } = stepper;
+
+    let _inputTxt = String(value);
+    if (_inputTxt.lastIndexOf('.') + 1 == _inputTxt.length || _inputTxt.lastIndexOf(',') + 1 == _inputTxt.length) {
+      if (_inputTxt.lastIndexOf('.') != _inputTxt.indexOf('.') || _inputTxt.lastIndexOf(',') != _inputTxt.indexOf(',')) {
+        _inputTxt = _inputTxt.slice(0, -1);
+        stepper.value = _inputTxt;
+        stepper.$inputEl.val(stepper.value);
+        return;
+      }
+    } else {
+      let value = parseFloat(_inputTxt.replace(',', '.'));
+      if (value === 0) {
+        stepper.value = _inputTxt.replace(',', '.');
+        stepper.$inputEl.val(stepper.value);
+        return;
+      }
+      if (isNaN(value)) {
+        stepper.value = 0;
+        stepper.$inputEl.val(stepper.value);
+        return;
+      }
+      else {
+        const powVal = Math.pow(10, stepper.params.decimalPoint);
+        value = (Math.round((value) * powVal)).toFixed(stepper.params.decimalPoint + 1) / powVal;
+        stepper.value = parseFloat(String(value).replace(',', '.'));
+        stepper.$inputEl.val(stepper.value);
+        return;
+      }
+    }
+    stepper.value = _inputTxt;
+    stepper.$inputEl.val(_inputTxt);
+    return stepper;
+  };
 
   getValue() {
     return this.value;


### PR DESCRIPTION
Hello Developers,

Firstly I want say: Great job or even excellent!

I needed new functionality in stepper component that would allow me to set values manually from keypad in mobile.
Therefore, I added to stepper some functions described bellow:

- Add params decimalPoint to determine decimal part length.
- Add parameter buttonsEndInputMode to determine if clicking on +/- ends input mode
- By clicking on input field, stepper enter into "manualInput" mode, and stay in it while user press enter or stepper input lose focus.
- After click input, cursor go to end automaticaly.
- In manualInput mode, stepper checks if input value are correct and modyfies it if necessery.
- manual mode are only available without "readonly" params.

I tested this on real device and seems to be worked fine, but I can write another changes or additional functions.

Sorry for bad English, but it isn't my regular language.
