### PR TITLE
popover.open() should return popover

### DIFF
--- a/src/core/components/popover/popover-class.js
+++ b/src/core/components/popover/popover-class.js
@@ -76,7 +76,7 @@ class Popover extends Modal {
           popover.$targetEl = $(targetEl);
           popover.targetEl = popover.$targetEl[0];
         }
-        originalOpen.call(popover, animate);
+        return originalOpen.call(popover, animate);
       },
     });
 


### PR DESCRIPTION
I think it was a typo. If modal is not returned here closeOnSelect f.e. doesnt work as expected
