### PR TITLE
onChange event listener attached on smart-select select every time s…

### DIFF
--- a/src/js/framework7/smart-select.js
+++ b/src/js/framework7/smart-select.js
@@ -48,22 +48,23 @@ app.initSmartSelects = function (pageContainer) {
                 itemAfter.text(valueText.join(', '));
             }
         }
-
-        $select.on('change', function () {
-            var valueText = [];
-            for (var i = 0; i < select.length; i++) {
-                if (select[i].selected) {
-                    var displayAs = select[i].dataset ? select[i].dataset.displayAs : $(select[i]).data('display-as');
-                	if (displayAs && typeof displayAs !== 'undefined') {
-						valueText.push(displayAs);
-					} else {
-						valueText.push(select[i].textContent.trim());
-					}
-				}
+        if(!smartSelect.hasClass("smart-select-initialized")){
+            $select.on('change', function () {
+                var valueText = [];
+                for (var i = 0; i < select.length; i++) {
+                    if (select[i].selected) {
+                        var displayAs = select[i].dataset ? select[i].dataset.displayAs : $(select[i]).data('display-as');
+                      if (displayAs && typeof displayAs !== 'undefined') {
+                valueText.push(displayAs);
+              } else {
+                valueText.push(select[i].textContent.trim());
+              }
             }
-            smartSelect.find('.item-after').text(valueText.join(', '));
-        });
-
+                }
+                smartSelect.find('.item-after').text(valueText.join(', '));
+            });
+        }
+        smartSelect.addClass("smart-select-initialized");
     });
 
 };


### PR DESCRIPTION
…martSelectAddOption is called

When app.smartSelectAddOption() is called it triggers app.initSmartSelects which attach an onChange event listener every time.
this causes smart select to freeze for 10 seconds if ~1000 options where added dynamically.
this fix will add a new class *smart-select-initialized* the first time the smart select is initialized to prevent attaching the event listener more than once

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/framework7io/framework7/blob/master/.github/CONTRIBUTING.md) when submitting a pull request.
