### PR TITLE
 better swipeback on rtl theme 

### DIFF
--- a/src/core/modules/router/swipe-back.js
+++ b/src/core/modules/router/swipe-back.js
@@ -54,7 +54,7 @@ function SwipeBack(r) {
     const pageX = e.type === 'touchmove' ? e.targetTouches[0].pageX : e.pageX;
     const pageY = e.type === 'touchmove' ? e.targetTouches[0].pageY : e.pageY;
     if (typeof isScrolling === 'undefined') {
-      isScrolling = !!(isScrolling || Math.abs(pageY - touchesStart.y) > Math.abs(pageX - touchesStart.x)) || pageX < touchesStart.x;
+      isScrolling = !!(isScrolling || Math.abs(pageY - touchesStart.y) > Math.abs(pageX - touchesStart.x)) || (pageX < touchesStart.x && !app.rtl ) || (pageX > touchesStart.x && app.rtl );
     }
     if (isScrolling || e.f7PreventSwipeBack || app.preventSwipeBack) {
       isTouched = false;

--- a/src/core/modules/router/swipe-back.js
+++ b/src/core/modules/router/swipe-back.js
@@ -54,7 +54,7 @@ function SwipeBack(r) {
     const pageX = e.type === 'touchmove' ? e.targetTouches[0].pageX : e.pageX;
     const pageY = e.type === 'touchmove' ? e.targetTouches[0].pageY : e.pageY;
     if (typeof isScrolling === 'undefined') {
-      isScrolling = !!(isScrolling || Math.abs(pageY - touchesStart.y) > Math.abs(pageX - touchesStart.x)) || (pageX < touchesStart.x && !app.rtl ) || (pageX > touchesStart.x && app.rtl );
+      isScrolling = !!(isScrolling || Math.abs(pageY - touchesStart.y) > Math.abs(pageX - touchesStart.x)) || (pageX < touchesStart.x && !app.rtl) || (pageX > touchesStart.x && app.rtl);
     }
     if (isScrolling || e.f7PreventSwipeBack || app.preventSwipeBack) {
       isTouched = false;


### PR DESCRIPTION
I faced a problem that swipe-back on rtl theme triggered very hard! you should swipe from very very right edge and sometimes it is triggered and sometime(most of the time) no luck. 
I checked the `swipe-back.js` and with changing this line problem seems to be solved and swipe-back on rtl triggered smoothly