### PR TITLE
Pass searchbar param through smartSelect, render notFoundElement for SS

### DIFF
--- a/src/core/components/smart-select/smart-select-class.js
+++ b/src/core/components/smart-select/smart-select-class.js
@@ -430,12 +430,31 @@ class SmartSelect extends Framework7Class {
       if (type === 'page' && app.theme === 'ios') {
         $searchbarEl = $(app.navbar.getElByPage($containerEl)).find('.searchbar');
       }
-      ss.searchbar = app.searchbar.create({
+
+      if(ss.params.appendSearchbarNotFound && (type === 'page' || type === 'popup')){
+        let $notFoundEl = null;
+
+        if (typeof ss.params.appendSearchbarNotFound == "string"){
+          $notFoundEl = $(`<div class="block searchbar-not-found">${ss.params.appendSearchbarNotFound}</div>`);
+        } else if (typeof ss.params.appendSearchbarNotFound == "boolean"){
+          $notFoundEl = $(`<div class="block searchbar-not-found">Nothing found</div>`);
+        } else {
+          $notFoundEl = ss.params.appendSearchbarNotFound;
+        }
+
+        if ($notFoundEl){
+          $containerEl.find('.page-content').append($notFoundEl[0]);
+        }
+      }
+
+      const searchbarParams = Utils.extend({
         el: $searchbarEl,
         backdropEl: $containerEl.find('.searchbar-backdrop'),
         searchContainer: `.smart-select-list-${ss.id}`,
         searchIn: '.item-title',
-      });
+      }, typeof ss.params.searchbar == "object" ? ss.params.searchbar : {})
+
+      ss.searchbar = app.searchbar.create(searchbarParams);
     }
 
     // Check for max length


### PR DESCRIPTION
Currently SmartSelect allows to render a searchbar. But you cannot pass parameters for it. For example `on` parameters for handling events on searchbar. 

I propose to allow SmartSelect's parameter `searchbar` receive an object which then will be treated as searchbar's parameters and searchbar will be inited using this object.

The other addition which I propose is adding to SmartSelect `appendSearchbarNotFound` parameter which can be:
- _boolean_ then default element `<div class="block searchbar-not-found">Nothing found</div>` will be rendered
- _string_ then default element `<div class="block searchbar-not-found">${ss.params.appendSearchbarNotFound}</div>` will be rendered with given label
- _Dom7 element_ then it's first HTMLElement will be rendered

**This will allow for example adding a new item to smartselect options:**
Say we have a React app and a page where we can select some tags. 
```
   ...
   constructor(props){
        this.state = {
            tagOptions: ['aaa', 'ccc'],  //already known tags that can be selected
            tags: []                                //currently assigned tags
        }
   }
   ...
   render(){
      return <Link smartSelect smartSelectParams={{
                  pageTitle: 'Tags',
                  appendSearchbarNotFound: true,
                  searchbar: {
                    on: {
                      search(sb, query, previousQuery){
                        query = query.trim();

                        sb.$notFoundEl.empty();
                        if(query.length > 2){
                          const el = sb.app.$('<a/>');
                          el.addClass('link').text(`Add "${query}"...`);
                          el.once('click', ()=>{
                            const tagsOptions = self.state.tagsOptions;
                            tagsOptions.push(query)
                            tagsOptions.sort();
                            tags.push(query);
                            tags.sort();
                            self.setState({tagsOptions, tags});

                            const $ssEl = sb.app.$('select[name="tags"]').parents('.smart-select');
                            const ss = sb.app.smartSelect.get($ssEl);

                            const $listEl = ss.$containerEl.find('.list ul');
                            $listEl.empty();
                            ss.getItemsData();
                            $listEl.append(ss.renderItems());
                            sb.clear();
                            sb.disable();
                          })
                          sb.$notFoundEl.append(el)
                        }else{
                          sb.$notFoundEl.text('Nothing found. Input at least 3 characters to create a new tag.')
                        }
                      }
                    }
                  },
                  openIn: 'popup', routableModals: false,
                }}>
                <select name="tags" multiple value={tags} onChange={(e) => this.setState({ tags:  [].filter.call(e.target.options, o => o.selected).map(o => o.value))}}>
                  {this.state.tagsOptions.map((tag, i)=>(
                    <option value={tag} key={i}>{tag}</option>
                  ))}
                </select>
                Add tag...
              </Link>
   }
```

