### PR TITLE
add `backdrop` option for `calendar`

### DIFF
--- a/src/core/components/calendar/calendar-class.js
+++ b/src/core/components/calendar/calendar-class.js
@@ -1356,6 +1356,7 @@ class Calendar extends Framework7Class {
       scrollToEl: calendar.params.scrollToInput ? $inputEl : undefined,
       content: modalContent,
       backdrop: calendar.params.backdrop,
+      closeByBackdropClick: calendar.params.closeByBackdropClick,
       on: {
         open() {
           const modal = this;

--- a/src/core/components/calendar/calendar-class.js
+++ b/src/core/components/calendar/calendar-class.js
@@ -1355,7 +1355,7 @@ class Calendar extends Framework7Class {
       targetEl: $inputEl,
       scrollToEl: calendar.params.scrollToInput ? $inputEl : undefined,
       content: modalContent,
-      backdrop: calendar.params.backdrop === true || (modalType === 'popover' && app.params.popover.backdrop !== false && calendar.params.backdrop !== false) ,
+      backdrop: calendar.params.backdrop === true || (modalType === 'popover' && app.params.popover.backdrop !== false && calendar.params.backdrop !== false),
       closeByBackdropClick: calendar.params.closeByBackdropClick,
       on: {
         open() {

--- a/src/core/components/calendar/calendar-class.js
+++ b/src/core/components/calendar/calendar-class.js
@@ -1355,7 +1355,7 @@ class Calendar extends Framework7Class {
       targetEl: $inputEl,
       scrollToEl: calendar.params.scrollToInput ? $inputEl : undefined,
       content: modalContent,
-      backdrop: modalType === 'popover' && app.params.popover.backdrop !== false,
+      backdrop: calendar.params.backdrop,
       on: {
         open() {
           const modal = this;

--- a/src/core/components/calendar/calendar-class.js
+++ b/src/core/components/calendar/calendar-class.js
@@ -1355,7 +1355,7 @@ class Calendar extends Framework7Class {
       targetEl: $inputEl,
       scrollToEl: calendar.params.scrollToInput ? $inputEl : undefined,
       content: modalContent,
-      backdrop: calendar.params.backdrop,
+      backdrop: (modalType === 'popover' && app.params.popover.backdrop !== false) || calendar.params.backdrop,
       closeByBackdropClick: calendar.params.closeByBackdropClick,
       on: {
         open() {

--- a/src/core/components/calendar/calendar-class.js
+++ b/src/core/components/calendar/calendar-class.js
@@ -1355,7 +1355,7 @@ class Calendar extends Framework7Class {
       targetEl: $inputEl,
       scrollToEl: calendar.params.scrollToInput ? $inputEl : undefined,
       content: modalContent,
-      backdrop: (modalType === 'popover' && app.params.popover.backdrop !== false) || calendar.params.backdrop,
+      backdrop: calendar.params.backdrop === true || (modalType === 'popover' && app.params.popover.backdrop !== false && calendar.params.backdrop !== false) ,
       closeByBackdropClick: calendar.params.closeByBackdropClick,
       on: {
         open() {

--- a/src/core/components/calendar/calendar.js
+++ b/src/core/components/calendar/calendar.js
@@ -76,7 +76,7 @@ export default {
       routableModals: true,
       view: null,
       url: 'date/',
-      backdrop: false,
+      backdrop: null,
       closeByBackdropClick: true,
       // Render functions
       renderWeekHeader: null,

--- a/src/core/components/calendar/calendar.js
+++ b/src/core/components/calendar/calendar.js
@@ -77,6 +77,7 @@ export default {
       view: null,
       url: 'date/',
       backdrop: true,
+      closeByBackdropClick: true,
       // Render functions
       renderWeekHeader: null,
       renderMonths: null,

--- a/src/core/components/calendar/calendar.js
+++ b/src/core/components/calendar/calendar.js
@@ -76,6 +76,7 @@ export default {
       routableModals: true,
       view: null,
       url: 'date/',
+      backdrop: true,
       // Render functions
       renderWeekHeader: null,
       renderMonths: null,

--- a/src/core/components/calendar/calendar.js
+++ b/src/core/components/calendar/calendar.js
@@ -76,7 +76,7 @@ export default {
       routableModals: true,
       view: null,
       url: 'date/',
-      backdrop: true,
+      backdrop: false,
       closeByBackdropClick: true,
       // Render functions
       renderWeekHeader: null,


### PR DESCRIPTION
Hi
Right now `backdrop` is available only when calendar's type is popover, but when it is`customModal` or `sheet` it may be needed too. (I myself needed this for `customModal` badly!)
I added `closeByBackdropClick` too.