### PR TITLE
optimizing toolbar.js “no-toolbar”

### DIFF
--- a/packages/core/components/toolbar/toolbar.js
+++ b/packages/core/components/toolbar/toolbar.js
@@ -155,10 +155,10 @@ export default {
       const app = this;
       let $toolbarEl = page.$el.parents('.view').children('.toolbar');
       if ($toolbarEl.length === 0) {
-        $toolbarEl = page.$el.find('.toolbar');
+        $toolbarEl = page.$el.parents('.views').children('.tabbar, .tabbar-labels');
       }
       if ($toolbarEl.length === 0) {
-        $toolbarEl = page.$el.parents('.views').children('.tabbar, .tabbar-labels');
+        $toolbarEl = page.$el.find('.toolbar');
       }
       if ($toolbarEl.length === 0) {
         return;


### PR DESCRIPTION
"toolbar div" and "no-toolbar property" exist together pageBeforeIn,  all the other "toolbars div" should hide,  cover  `page.$el.parents('.views').children('.tabbar, .tabbar-labels')`.

if not,    .views > .tabbar, .tabbar-labels can't hide().

please give your comment. tks.