### PR TITLE
Declare `side` argument optional in panel.[open|close]

### DIFF
--- a/src/core/components/panel/panel.d.ts
+++ b/src/core/components/panel/panel.d.ts
@@ -86,9 +86,9 @@ export namespace Panel {
   interface AppMethods {
     panel: {
       /** open panel */
-      open(side : 'left' | 'right', animate?: boolean) : boolean
+      open(side?: 'left' | 'right', animate?: boolean) : boolean
       /** close panel */
-      close(side : 'left' | 'right', animate?: boolean) : boolean
+      close(side?: 'left' | 'right', animate?: boolean) : boolean
       /** create new panel instance */
       create(parameters : Parameters) : Panel
       /** get Panel instance by specified side */


### PR DESCRIPTION
The types currently force you to provide a `side` argument for `panel.open`/`panel.close`. This relaxes the types to make that optional.