### PR TITLE
Add className and style props to React component types

### DIFF
--- a/packages/react/components/accordion-content.d.ts
+++ b/packages/react/components/accordion-content.d.ts
@@ -4,6 +4,8 @@ namespace F7AccordionContent {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     color? : string
     colorTheme? : string
     textColor? : string

--- a/packages/react/components/accordion-item.d.ts
+++ b/packages/react/components/accordion-item.d.ts
@@ -4,6 +4,8 @@ namespace F7AccordionItem {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     opened? : boolean
     color? : string
     colorTheme? : string

--- a/packages/react/components/accordion-toggle.d.ts
+++ b/packages/react/components/accordion-toggle.d.ts
@@ -4,6 +4,8 @@ namespace F7AccordionToggle {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     color? : string
     colorTheme? : string
     textColor? : string

--- a/packages/react/components/accordion.d.ts
+++ b/packages/react/components/accordion.d.ts
@@ -4,6 +4,8 @@ namespace F7Accordion {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     color? : string
     colorTheme? : string
     textColor? : string

--- a/packages/react/components/actions-button.d.ts
+++ b/packages/react/components/actions-button.d.ts
@@ -4,6 +4,8 @@ namespace F7ActionsButton {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     bold? : boolean
     close? : boolean  | true
     color? : string

--- a/packages/react/components/actions-group.d.ts
+++ b/packages/react/components/actions-group.d.ts
@@ -4,6 +4,8 @@ namespace F7ActionsGroup {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     color? : string
     colorTheme? : string
     textColor? : string

--- a/packages/react/components/actions-label.d.ts
+++ b/packages/react/components/actions-label.d.ts
@@ -4,6 +4,8 @@ namespace F7ActionsLabel {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     bold? : boolean
     color? : string
     colorTheme? : string

--- a/packages/react/components/actions.d.ts
+++ b/packages/react/components/actions.d.ts
@@ -4,6 +4,8 @@ namespace F7Actions {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     opened? : boolean
     grid? : boolean
     convertToPopover? : boolean

--- a/packages/react/components/app.d.ts
+++ b/packages/react/components/app.d.ts
@@ -4,6 +4,8 @@ namespace F7App {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     params? : Object
     routes? : Array<any>
     color? : string

--- a/packages/react/components/badge.d.ts
+++ b/packages/react/components/badge.d.ts
@@ -4,6 +4,8 @@ namespace F7Badge {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     color? : string
     colorTheme? : string
     textColor? : string

--- a/packages/react/components/block-footer.d.ts
+++ b/packages/react/components/block-footer.d.ts
@@ -4,6 +4,8 @@ namespace F7BlockFooter {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     color? : string
     colorTheme? : string
     textColor? : string

--- a/packages/react/components/block-header.d.ts
+++ b/packages/react/components/block-header.d.ts
@@ -4,6 +4,8 @@ namespace F7BlockHeader {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     color? : string
     colorTheme? : string
     textColor? : string

--- a/packages/react/components/block-title.d.ts
+++ b/packages/react/components/block-title.d.ts
@@ -4,6 +4,8 @@ namespace F7BlockTitle {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     color? : string
     colorTheme? : string
     textColor? : string

--- a/packages/react/components/block.d.ts
+++ b/packages/react/components/block.d.ts
@@ -4,6 +4,8 @@ namespace F7Block {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     inset? : boolean
     tabletInset? : boolean
     strong? : boolean

--- a/packages/react/components/button.d.ts
+++ b/packages/react/components/button.d.ts
@@ -4,6 +4,8 @@ namespace F7Button {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     noFastclick? : boolean
     noFastClick? : boolean
     text? : string

--- a/packages/react/components/card-content.d.ts
+++ b/packages/react/components/card-content.d.ts
@@ -4,6 +4,8 @@ namespace F7CardContent {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     padding? : boolean  | true
     color? : string
     colorTheme? : string

--- a/packages/react/components/card-footer.d.ts
+++ b/packages/react/components/card-footer.d.ts
@@ -4,6 +4,8 @@ namespace F7CardFooter {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     color? : string
     colorTheme? : string
     textColor? : string

--- a/packages/react/components/card-header.d.ts
+++ b/packages/react/components/card-header.d.ts
@@ -4,6 +4,8 @@ namespace F7CardHeader {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     color? : string
     colorTheme? : string
     textColor? : string

--- a/packages/react/components/card.d.ts
+++ b/packages/react/components/card.d.ts
@@ -4,6 +4,8 @@ namespace F7Card {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     title? : string | number
     content? : string | number
     footer? : string | number

--- a/packages/react/components/checkbox.d.ts
+++ b/packages/react/components/checkbox.d.ts
@@ -4,6 +4,8 @@ namespace F7Checkbox {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     checked? : boolean
     name? : number | string
     value? : number | string | boolean

--- a/packages/react/components/chip.d.ts
+++ b/packages/react/components/chip.d.ts
@@ -4,6 +4,8 @@ namespace F7Chip {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     media? : string
     text? : string | number
     deleteable? : boolean

--- a/packages/react/components/col.d.ts
+++ b/packages/react/components/col.d.ts
@@ -4,6 +4,8 @@ namespace F7Col {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     tag? : string  | 'div'
     width? : number | string  | 'auto'
     tabletWidth? : number | string

--- a/packages/react/components/fab-button.d.ts
+++ b/packages/react/components/fab-button.d.ts
@@ -4,6 +4,8 @@ namespace F7FabButton {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     fabClose? : boolean
     label? : string
     target? : string

--- a/packages/react/components/fab-buttons.d.ts
+++ b/packages/react/components/fab-buttons.d.ts
@@ -4,6 +4,8 @@ namespace F7FabButtons {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     position? : string  | 'top'
     color? : string
     colorTheme? : string

--- a/packages/react/components/fab.d.ts
+++ b/packages/react/components/fab.d.ts
@@ -4,6 +4,8 @@ namespace F7Fab {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     morphTo? : string
     href? : boolean | string
     target? : string

--- a/packages/react/components/gauge.d.ts
+++ b/packages/react/components/gauge.d.ts
@@ -4,6 +4,8 @@ namespace F7Gauge {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     type? : string  | 'circle'
     value? : number | string  | 0
     size? : number | string  | 200

--- a/packages/react/components/icon.d.ts
+++ b/packages/react/components/icon.d.ts
@@ -4,6 +4,8 @@ namespace F7Icon {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     material? : string
     f7? : string
     ion? : string

--- a/packages/react/components/input.d.ts
+++ b/packages/react/components/input.d.ts
@@ -9,7 +9,11 @@ namespace F7Input {
     defaultValue? : string | number | Array<any>
     placeholder? : string
     id? : string | number
-    inputId? : string | number
+    className? : string
+    style? : React.CSSProperties
+    inputid? : string | number
+    className? : string
+    style? : React.CSSProperties
     size? : string | number
     accept? : string | number
     autocomplete? : string

--- a/packages/react/components/label.d.ts
+++ b/packages/react/components/label.d.ts
@@ -4,6 +4,8 @@ namespace F7Label {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     floating? : boolean
     inline? : boolean
     color? : string

--- a/packages/react/components/link.d.ts
+++ b/packages/react/components/link.d.ts
@@ -4,6 +4,8 @@ namespace F7Link {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     noLinkClass? : boolean
     noFastClick? : boolean
     noFastclick? : boolean

--- a/packages/react/components/list-button.d.ts
+++ b/packages/react/components/list-button.d.ts
@@ -4,6 +4,8 @@ namespace F7ListButton {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     noFastclick? : boolean
     noFastClick? : boolean
     title? : string | number

--- a/packages/react/components/list-group.d.ts
+++ b/packages/react/components/list-group.d.ts
@@ -4,6 +4,8 @@ namespace F7ListGroup {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     mediaList? : boolean
     sortable? : boolean
     color? : string

--- a/packages/react/components/list-index.d.ts
+++ b/packages/react/components/list-index.d.ts
@@ -4,6 +4,8 @@ namespace F7ListIndex {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     init? : boolean  | true
     listEl? : string | Object
     indexes? : string | Array<any>  | 'auto'

--- a/packages/react/components/list-item-cell.d.ts
+++ b/packages/react/components/list-item-cell.d.ts
@@ -4,6 +4,8 @@ namespace F7ListItemCell {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     color? : string
     colorTheme? : string
     textColor? : string

--- a/packages/react/components/list-item-content.d.ts
+++ b/packages/react/components/list-item-content.d.ts
@@ -4,6 +4,8 @@ namespace F7ListItemContent {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     title? : string | number
     text? : string | number
     media? : string

--- a/packages/react/components/list-item-row.d.ts
+++ b/packages/react/components/list-item-row.d.ts
@@ -4,6 +4,8 @@ namespace F7ListItemRow {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     color? : string
     colorTheme? : string
     textColor? : string

--- a/packages/react/components/list-item.d.ts
+++ b/packages/react/components/list-item.d.ts
@@ -4,6 +4,8 @@ namespace F7ListItem {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     title? : string | number
     text? : string | number
     media? : string

--- a/packages/react/components/list.d.ts
+++ b/packages/react/components/list.d.ts
@@ -4,6 +4,8 @@ namespace F7List {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     inset? : boolean
     tabletInset? : boolean
     mediaList? : boolean

--- a/packages/react/components/login-screen-title.d.ts
+++ b/packages/react/components/login-screen-title.d.ts
@@ -4,6 +4,8 @@ namespace F7LoginScreenTitle {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     color? : string
     colorTheme? : string
     textColor? : string

--- a/packages/react/components/login-screen.d.ts
+++ b/packages/react/components/login-screen.d.ts
@@ -4,6 +4,8 @@ namespace F7LoginScreen {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     opened? : boolean
     color? : string
     colorTheme? : string

--- a/packages/react/components/message.d.ts
+++ b/packages/react/components/message.d.ts
@@ -4,6 +4,8 @@ namespace F7Message {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     text? : string
     name? : string
     avatar? : string

--- a/packages/react/components/messagebar-attachment.d.ts
+++ b/packages/react/components/messagebar-attachment.d.ts
@@ -4,6 +4,8 @@ namespace F7MessagebarAttachment {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     image? : string
     deletable? : boolean  | true
     color? : string

--- a/packages/react/components/messagebar-attachments.d.ts
+++ b/packages/react/components/messagebar-attachments.d.ts
@@ -4,6 +4,8 @@ namespace F7MessagebarAttachments {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     color? : string
     colorTheme? : string
     textColor? : string

--- a/packages/react/components/messagebar-sheet-image.d.ts
+++ b/packages/react/components/messagebar-sheet-image.d.ts
@@ -4,6 +4,8 @@ namespace F7MessagebarSheetImage {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     image? : string
     checked? : boolean
     color? : string

--- a/packages/react/components/messagebar-sheet-item.d.ts
+++ b/packages/react/components/messagebar-sheet-item.d.ts
@@ -4,6 +4,8 @@ namespace F7MessagebarSheetItem {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     color? : string
     colorTheme? : string
     textColor? : string

--- a/packages/react/components/messagebar-sheet.d.ts
+++ b/packages/react/components/messagebar-sheet.d.ts
@@ -4,6 +4,8 @@ namespace F7MessagebarSheet {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     color? : string
     colorTheme? : string
     textColor? : string

--- a/packages/react/components/messagebar.d.ts
+++ b/packages/react/components/messagebar.d.ts
@@ -4,6 +4,8 @@ namespace F7Messagebar {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     sheetVisible? : boolean
     attachmentsVisible? : boolean
     top? : boolean

--- a/packages/react/components/messages-title.d.ts
+++ b/packages/react/components/messages-title.d.ts
@@ -4,6 +4,8 @@ namespace F7MessagesTitle {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     color? : string
     colorTheme? : string
     textColor? : string

--- a/packages/react/components/messages.d.ts
+++ b/packages/react/components/messages.d.ts
@@ -4,6 +4,8 @@ namespace F7Messages {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     autoLayout? : boolean  | false
     messages? : Array<any>  | function(){return[];}
     newMessagesFirst? : boolean  | false

--- a/packages/react/components/nav-left.d.ts
+++ b/packages/react/components/nav-left.d.ts
@@ -4,6 +4,8 @@ namespace F7NavLeft {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     backLink? : boolean | string
     backLinkUrl? : string
     backLinkForce? : boolean

--- a/packages/react/components/nav-right.d.ts
+++ b/packages/react/components/nav-right.d.ts
@@ -4,6 +4,8 @@ namespace F7NavRight {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     sliding? : boolean
     color? : string
     colorTheme? : string

--- a/packages/react/components/nav-title.d.ts
+++ b/packages/react/components/nav-title.d.ts
@@ -4,6 +4,8 @@ namespace F7NavTitle {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     title? : string
     subtitle? : string
     sliding? : boolean

--- a/packages/react/components/navbar.d.ts
+++ b/packages/react/components/navbar.d.ts
@@ -4,6 +4,8 @@ namespace F7Navbar {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     backLink? : boolean | string
     backLinkUrl? : string
     backLinkForce? : boolean

--- a/packages/react/components/page-content.d.ts
+++ b/packages/react/components/page-content.d.ts
@@ -4,6 +4,8 @@ namespace F7PageContent {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     tab? : boolean
     tabActive? : boolean
     ptr? : boolean

--- a/packages/react/components/page.d.ts
+++ b/packages/react/components/page.d.ts
@@ -4,6 +4,8 @@ namespace F7Page {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     name? : string
     stacked? : boolean
     withSubnavbar? : boolean

--- a/packages/react/components/panel.d.ts
+++ b/packages/react/components/panel.d.ts
@@ -4,6 +4,8 @@ namespace F7Panel {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     side? : string
     effect? : string
     cover? : boolean

--- a/packages/react/components/photo-browser.d.ts
+++ b/packages/react/components/photo-browser.d.ts
@@ -4,6 +4,8 @@ namespace F7PhotoBrowser {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     init? : boolean  | true
     params? : Object
     photos? : Array<any>

--- a/packages/react/components/popover.d.ts
+++ b/packages/react/components/popover.d.ts
@@ -4,6 +4,8 @@ namespace F7Popover {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     opened? : boolean
     target? : string | Object
     closeByBackdropClick? : boolean

--- a/packages/react/components/popup.d.ts
+++ b/packages/react/components/popup.d.ts
@@ -4,6 +4,8 @@ namespace F7Popup {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     tabletFullscreen? : boolean
     opened? : boolean
     closeByBackdropClick? : boolean

--- a/packages/react/components/preloader.d.ts
+++ b/packages/react/components/preloader.d.ts
@@ -4,6 +4,8 @@ namespace F7Preloader {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     size? : number | string
     color? : string
     colorTheme? : string

--- a/packages/react/components/progressbar.d.ts
+++ b/packages/react/components/progressbar.d.ts
@@ -4,6 +4,8 @@ namespace F7Progressbar {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     progress? : number
     infinite? : boolean
     color? : string

--- a/packages/react/components/radio.d.ts
+++ b/packages/react/components/radio.d.ts
@@ -4,6 +4,8 @@ namespace F7Radio {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     checked? : boolean
     name? : number | string
     value? : number | string | boolean

--- a/packages/react/components/range.d.ts
+++ b/packages/react/components/range.d.ts
@@ -4,6 +4,8 @@ namespace F7Range {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     init? : boolean  | true
     value? : number | Array<any> | string  | 0
     min? : number | string  | 0

--- a/packages/react/components/row.d.ts
+++ b/packages/react/components/row.d.ts
@@ -4,6 +4,8 @@ namespace F7Row {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     noGap? : boolean
     tag? : string  | 'div'
     color? : string

--- a/packages/react/components/searchbar.d.ts
+++ b/packages/react/components/searchbar.d.ts
@@ -4,6 +4,8 @@ namespace F7Searchbar {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     noShadow? : boolean
     noHairline? : boolean
     form? : boolean  | true

--- a/packages/react/components/segmented.d.ts
+++ b/packages/react/components/segmented.d.ts
@@ -4,6 +4,8 @@ namespace F7Segmented {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     raised? : boolean
     round? : boolean
     tag? : string  | 'div'

--- a/packages/react/components/sheet.d.ts
+++ b/packages/react/components/sheet.d.ts
@@ -4,6 +4,8 @@ namespace F7Sheet {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     opened? : boolean
     backdrop? : boolean
     closeByBackdropClick? : boolean

--- a/packages/react/components/statusbar.d.ts
+++ b/packages/react/components/statusbar.d.ts
@@ -4,6 +4,8 @@ namespace F7Statusbar {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     color? : string
     colorTheme? : string
     textColor? : string

--- a/packages/react/components/stepper.d.ts
+++ b/packages/react/components/stepper.d.ts
@@ -4,6 +4,8 @@ namespace F7Stepper {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     init? : boolean  | true
     value? : number  | 0
     min? : number  | 0

--- a/packages/react/components/subnavbar.d.ts
+++ b/packages/react/components/subnavbar.d.ts
@@ -4,6 +4,8 @@ namespace F7Subnavbar {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     sliding? : boolean
     title? : string
     inner? : boolean  | true

--- a/packages/react/components/swipeout-actions.d.ts
+++ b/packages/react/components/swipeout-actions.d.ts
@@ -4,6 +4,8 @@ namespace F7SwipeoutActions {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     left? : boolean
     right? : boolean
     side? : string

--- a/packages/react/components/swipeout-button.d.ts
+++ b/packages/react/components/swipeout-button.d.ts
@@ -4,6 +4,8 @@ namespace F7SwipeoutButton {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     text? : string
     confirmText? : string
     overswipe? : boolean

--- a/packages/react/components/swiper-slide.d.ts
+++ b/packages/react/components/swiper-slide.d.ts
@@ -4,6 +4,8 @@ namespace F7SwiperSlide {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     zoom? : boolean
     
   }

--- a/packages/react/components/swiper.d.ts
+++ b/packages/react/components/swiper.d.ts
@@ -4,6 +4,8 @@ namespace F7Swiper {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     params? : Object
     pagination? : boolean
     scrollbar? : boolean

--- a/packages/react/components/tab.d.ts
+++ b/packages/react/components/tab.d.ts
@@ -4,6 +4,8 @@ namespace F7Tab {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     tabActive? : boolean
     color? : string
     colorTheme? : string

--- a/packages/react/components/tabs.d.ts
+++ b/packages/react/components/tabs.d.ts
@@ -4,6 +4,8 @@ namespace F7Tabs {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     animated? : boolean
     swipeable? : boolean
     routable? : boolean

--- a/packages/react/components/toggle.d.ts
+++ b/packages/react/components/toggle.d.ts
@@ -4,6 +4,8 @@ namespace F7Toggle {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     init? : boolean  | true
     checked? : boolean
     defaultChecked? : boolean

--- a/packages/react/components/toolbar.d.ts
+++ b/packages/react/components/toolbar.d.ts
@@ -4,6 +4,8 @@ namespace F7Toolbar {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     bottomMd? : boolean
     tabbar? : boolean
     labels? : boolean

--- a/packages/react/components/view.d.ts
+++ b/packages/react/components/view.d.ts
@@ -4,6 +4,8 @@ namespace F7View {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     tab? : boolean
     tabActive? : boolean
     name? : string

--- a/packages/react/components/views.d.ts
+++ b/packages/react/components/views.d.ts
@@ -4,6 +4,8 @@ namespace F7Views {
   export interface Props {
     slot? : string
     id? : string | number
+    className? : string
+    style? : React.CSSProperties
     tabs? : boolean
     color? : string
     colorTheme? : string


### PR DESCRIPTION
Add missing `className` and `style` props to React component prop types.