### PR TITLE
Typescript fixes for compilation errors

### DIFF
--- a/packages/core/components/actions/actions.d.ts
+++ b/packages/core/components/actions/actions.d.ts
@@ -86,7 +86,7 @@ export namespace Actions {
     renderPopover?: () => string
     /** Object with event handlers */
     on?: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
   }
 

--- a/packages/core/components/autocomplete/autocomplete.d.ts
+++ b/packages/core/components/autocomplete/autocomplete.d.ts
@@ -127,7 +127,7 @@ export namespace Autocomplete {
     renderNavbar?: () => string
 
     on?: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
   }
 

--- a/packages/core/components/calendar/calendar.d.ts
+++ b/packages/core/components/calendar/calendar.d.ts
@@ -193,7 +193,7 @@ export namespace Calendar {
     render?: () => string
 
     on?: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
   }
 

--- a/packages/core/components/data-table/data-table.d.ts
+++ b/packages/core/components/data-table/data-table.d.ts
@@ -15,7 +15,7 @@ export namespace DataTable {
     el: HTMLElement
 
     on?: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
   }
 

--- a/packages/core/components/dialog/dialog.d.ts
+++ b/packages/core/components/dialog/dialog.d.ts
@@ -80,7 +80,7 @@ export namespace Dialog {
     cssClass?: string
     /** Object with events handlers.. */
     on?: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
   }
 

--- a/packages/core/components/gauge/gauge.d.ts
+++ b/packages/core/components/gauge/gauge.d.ts
@@ -57,7 +57,7 @@ export namespace Gauge {
     labelFontWeight?: string
     /** Object with events handlers.. */
     on?: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
   }
 

--- a/packages/core/components/list-index/list-index.d.ts
+++ b/packages/core/components/list-index/list-index.d.ts
@@ -47,7 +47,7 @@ export namespace ListIndex {
     mdItemHeight?: number
     /** Object with events handlers.. */
     on: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
   }
 

--- a/packages/core/components/login-screen/login-screen.d.ts
+++ b/packages/core/components/login-screen/login-screen.d.ts
@@ -31,7 +31,7 @@ export namespace LoginScreen {
     animate?: boolean
     /** Object with events handlers.. */
     on?: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
   }
 

--- a/packages/core/components/messagebar/messagebar.d.ts
+++ b/packages/core/components/messagebar/messagebar.d.ts
@@ -65,7 +65,7 @@ export namespace Messagebar {
     resizePage?: boolean
     /** Object with events handlers.. */
     on?: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
 
     /** Function to render attachments block. Must return full attachments HTML string. */

--- a/packages/core/components/messages/messages.d.ts
+++ b/packages/core/components/messages/messages.d.ts
@@ -74,7 +74,7 @@ export namespace Messages {
     messages?: Message[]
     /** Object with events handlers.. */
     on?: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
 
     /** Function to render single message. Must return full message HTML string. */

--- a/packages/core/components/modal/modal.d.ts
+++ b/packages/core/components/modal/modal.d.ts
@@ -36,7 +36,7 @@ export namespace Modal {
     animate?: boolean
     /** Object with events handlers.. */
     on?: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
   }
   interface Events {

--- a/packages/core/components/notification/notification.d.ts
+++ b/packages/core/components/notification/notification.d.ts
@@ -45,7 +45,7 @@ export namespace Notification {
     render?: () => string
     /** Object with events handlers.. */
     on?: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
   }
 

--- a/packages/core/components/picker/picker.d.ts
+++ b/packages/core/components/picker/picker.d.ts
@@ -106,7 +106,7 @@ export namespace Picker {
 
     /** Object with events handlers.. */
     on?: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
 
     /** String with CSS selector or HTMLElement where to place generated Picker HTML. Use only for inline picker. */

--- a/packages/core/components/popover/popover.d.ts
+++ b/packages/core/components/popover/popover.d.ts
@@ -40,7 +40,7 @@ export namespace Popover {
 
     /** Object with events handlers.. */
     on?: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
   }
   interface Popover extends Framework7EventsClass<Events> {

--- a/packages/core/components/popup/popup.d.ts
+++ b/packages/core/components/popup/popup.d.ts
@@ -28,7 +28,7 @@ export namespace Popup {
 
     /** Object with events handlers.. */
     on?: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
   }
   interface Popup extends Framework7EventsClass<Events> {

--- a/packages/core/components/range/range.d.ts
+++ b/packages/core/components/range/range.d.ts
@@ -23,7 +23,7 @@ export namespace Range {
     draggableBar?: boolean
     /** Object with events handlers.. */
     on?: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
   }
   interface Range extends Framework7EventsClass<Events> {

--- a/packages/core/components/searchbar/searchbar.d.ts
+++ b/packages/core/components/searchbar/searchbar.d.ts
@@ -45,7 +45,7 @@ export namespace Searchbar {
     expandable?: boolean
     /** Object with events handlers.. */
     on?: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
   }
   interface Searchbar extends Framework7EventsClass<Events> {

--- a/packages/core/components/sheet/sheet.d.ts
+++ b/packages/core/components/sheet/sheet.d.ts
@@ -32,7 +32,7 @@ export namespace Sheet {
 
     /** Object with events handlers.. */
     on?: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
   }
   interface Sheet extends Framework7EventsClass<Events> {

--- a/packages/core/components/smart-select/smart-select.d.ts
+++ b/packages/core/components/smart-select/smart-select.d.ts
@@ -77,7 +77,7 @@ export namespace SmartSelect {
 
     /** Object with events handlers.. */
     on?: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
   }
   interface SmartSelect extends Framework7EventsClass<Events> {

--- a/packages/core/components/stepper/stepper.d.ts
+++ b/packages/core/components/stepper/stepper.d.ts
@@ -33,7 +33,7 @@ export namespace Stepper {
     buttonsEndInputMode?: boolean
     /** Object with events handlers.. */
     on?: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
   }
   interface Stepper extends Framework7EventsClass<Events> {

--- a/packages/core/components/toast/toast.d.ts
+++ b/packages/core/components/toast/toast.d.ts
@@ -40,7 +40,7 @@ export namespace Toast {
 
     /** Object with events handlers.. */
     on?: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
   }
   interface Toast extends Framework7EventsClass<Events> {

--- a/packages/core/components/toggle/toggle.d.ts
+++ b/packages/core/components/toggle/toggle.d.ts
@@ -7,7 +7,7 @@ export namespace Toggle {
     el?: HTMLElement | CSSSelector
     /** Object with events handlers.. */
     on?: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
   }
   interface Toggle extends Framework7EventsClass<Events> {

--- a/packages/core/components/tooltip/tooltip.d.ts
+++ b/packages/core/components/tooltip/tooltip.d.ts
@@ -13,7 +13,7 @@ export namespace Tooltip {
     render?: (tooltip: Tooltip) => string
     /** Object with events handlers.. */
     on?: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
   }
   interface DomEvents {

--- a/packages/core/components/vi/vi.d.ts
+++ b/packages/core/components/vi/vi.d.ts
@@ -80,7 +80,7 @@ export namespace Vi {
     connectionProvider?: string
     /** Object with events handlers.. */
     on?: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
   }
   interface Events {

--- a/packages/core/components/view/view.d.ts
+++ b/packages/core/components/view/view.d.ts
@@ -121,7 +121,7 @@ export namespace View {
     pushStateOnLoad?: boolean
     /** Object with events handlers.. */
     on?: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
   }
   interface View extends Router.AppMethods{}

--- a/packages/core/components/virtual-list/virtual-list.d.ts
+++ b/packages/core/components/virtual-list/virtual-list.d.ts
@@ -106,7 +106,7 @@ export namespace VirtualList {
     searchAll?(query: string, items: any[]): any[]
     /** Object with events handlers.. */
     on?: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
   }
   interface Events {

--- a/packages/react/framework7-react.d.ts
+++ b/packages/react/framework7-react.d.ts
@@ -10,7 +10,7 @@
  * Released on: September 17, 2018
  */
 
-import * as React from 'react';
+import React from 'react';
 import { Dom7 } from 'dom7';
 import Framework7 from 'framework7';
 import { Framework7Plugin } from 'framework7/components/app/app-class';

--- a/packages/react/framework7-react.d.ts
+++ b/packages/react/framework7-react.d.ts
@@ -10,7 +10,7 @@
  * Released on: September 17, 2018
  */
 
-import React from 'react';
+import * as React from 'react';
 import { Dom7 } from 'dom7';
 import Framework7 from 'framework7';
 import { Framework7Plugin } from 'framework7/components/app/app-class';

--- a/scripts/build-react-typings.js
+++ b/scripts/build-react-typings.js
@@ -9,7 +9,7 @@ const rename = require('gulp-rename');
 const fs = require('fs');
 
 const importLib = `
-import React from 'react';
+import * as React from 'react';
 `.trim();
 
 const libExtension = `

--- a/src/core/components/actions/actions.d.ts
+++ b/src/core/components/actions/actions.d.ts
@@ -86,7 +86,7 @@ export namespace Actions {
     renderPopover?: () => string
     /** Object with event handlers */
     on?: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
   }
 

--- a/src/core/components/app/app-class.d.ts
+++ b/src/core/components/app/app-class.d.ts
@@ -1,10 +1,10 @@
 import { Dom7, Dom7Instance } from 'dom7'
 import Template7 from 'template7'
 import { Router } from '../../modules/router/router';
-import Device, { Device as DeviceInterface } from '../../utils/device';
-import Request, { Request as RequestInterface } from '../../utils/request';
-import Support, { Support as SupportInterface } from '../../utils/support';
-import Utils, { Utils as UtilsInterface } from '../../utils/utils';
+import { Device } from '../../utils/device';
+import { Request } from '../../utils/request';
+import { Support } from '../../utils/support';
+import { Utils } from '../../utils/utils';
 
 // Css Selector string is an option on many F7 methods
 // Giving this alias makes the typename show in the intellisense
@@ -147,10 +147,10 @@ declare class Framework7 implements Framework7 {
   constructor(parameters?: Framework7Params);
 
   static use(plugin : Framework7Plugin) : void;
-  static device: DeviceInterface = Device;
-  static request: RequestInterface = Request;
-  static support: SupportInterface = Support;
-  static utils: UtilsInterface = Utils;
+  static device: Device;
+  static request: Request;
+  static support: Support;
+  static utils: Utils;
 }
 
 export default Framework7;

--- a/src/core/components/app/app-class.d.ts
+++ b/src/core/components/app/app-class.d.ts
@@ -1,5 +1,5 @@
-import { Dom7, Dom7Instance } from 'Dom7'
-import Template7 from 'Template7'
+import { Dom7, Dom7Instance } from 'dom7'
+import Template7 from 'template7'
 import { Router } from '../../modules/router/router';
 import Device, { Device as DeviceInterface } from '../../utils/device';
 import Request, { Request as RequestInterface } from '../../utils/request';

--- a/src/core/components/autocomplete/autocomplete.d.ts
+++ b/src/core/components/autocomplete/autocomplete.d.ts
@@ -127,7 +127,7 @@ export namespace Autocomplete {
     renderNavbar?: () => string
 
     on?: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
   }
 

--- a/src/core/components/calendar/calendar.d.ts
+++ b/src/core/components/calendar/calendar.d.ts
@@ -193,7 +193,7 @@ export namespace Calendar {
     render?: () => string
 
     on?: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
   }
 

--- a/src/core/components/contacts-list/contacts-list.d.ts
+++ b/src/core/components/contacts-list/contacts-list.d.ts
@@ -1,6 +1,6 @@
 import Framework7, { CSSSelector, Framework7EventsClass, Framework7Plugin } from '../app/app-class';
 
-export namespace ContactList {
+export namespace ContactsList {
   interface AppMethods {
 
   }
@@ -12,5 +12,5 @@ export namespace ContactList {
   }
 }
 
-declare const ContactListComponent: Framework7Plugin;
-export default ContactListComponent;
+declare const ContactsListComponent: Framework7Plugin;
+export default ContactsListComponent;

--- a/src/core/components/data-table/data-table.d.ts
+++ b/src/core/components/data-table/data-table.d.ts
@@ -15,7 +15,7 @@ export namespace DataTable {
     el: HTMLElement
 
     on?: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
   }
 

--- a/src/core/components/dialog/dialog.d.ts
+++ b/src/core/components/dialog/dialog.d.ts
@@ -80,7 +80,7 @@ export namespace Dialog {
     cssClass?: string
     /** Object with events handlers.. */
     on?: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
   }
 

--- a/src/core/components/gauge/gauge.d.ts
+++ b/src/core/components/gauge/gauge.d.ts
@@ -57,7 +57,7 @@ export namespace Gauge {
     labelFontWeight?: string
     /** Object with events handlers.. */
     on?: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
   }
 

--- a/src/core/components/list-index/list-index.d.ts
+++ b/src/core/components/list-index/list-index.d.ts
@@ -47,7 +47,7 @@ export namespace ListIndex {
     mdItemHeight?: number
     /** Object with events handlers.. */
     on: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
   }
 

--- a/src/core/components/login-screen/login-screen.d.ts
+++ b/src/core/components/login-screen/login-screen.d.ts
@@ -31,7 +31,7 @@ export namespace LoginScreen {
     animate?: boolean
     /** Object with events handlers.. */
     on?: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
   }
 

--- a/src/core/components/messagebar/messagebar.d.ts
+++ b/src/core/components/messagebar/messagebar.d.ts
@@ -65,7 +65,7 @@ export namespace Messagebar {
     resizePage?: boolean
     /** Object with events handlers.. */
     on?: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
 
     /** Function to render attachments block. Must return full attachments HTML string. */

--- a/src/core/components/messages/messages.d.ts
+++ b/src/core/components/messages/messages.d.ts
@@ -74,7 +74,7 @@ export namespace Messages {
     messages?: Message[]
     /** Object with events handlers.. */
     on?: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
 
     /** Function to render single message. Must return full message HTML string. */

--- a/src/core/components/modal/modal.d.ts
+++ b/src/core/components/modal/modal.d.ts
@@ -36,7 +36,7 @@ export namespace Modal {
     animate?: boolean
     /** Object with events handlers.. */
     on?: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
   }
   interface Events {

--- a/src/core/components/notification/notification.d.ts
+++ b/src/core/components/notification/notification.d.ts
@@ -45,7 +45,7 @@ export namespace Notification {
     render?: () => string
     /** Object with events handlers.. */
     on?: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
   }
 

--- a/src/core/components/picker/picker.d.ts
+++ b/src/core/components/picker/picker.d.ts
@@ -106,7 +106,7 @@ export namespace Picker {
 
     /** Object with events handlers.. */
     on?: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
 
     /** String with CSS selector or HTMLElement where to place generated Picker HTML. Use only for inline picker. */

--- a/src/core/components/popover/popover.d.ts
+++ b/src/core/components/popover/popover.d.ts
@@ -40,7 +40,7 @@ export namespace Popover {
 
     /** Object with events handlers.. */
     on?: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
   }
   interface Popover extends Framework7EventsClass<Events> {

--- a/src/core/components/popup/popup.d.ts
+++ b/src/core/components/popup/popup.d.ts
@@ -28,7 +28,7 @@ export namespace Popup {
 
     /** Object with events handlers.. */
     on?: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
   }
   interface Popup extends Framework7EventsClass<Events> {

--- a/src/core/components/range/range.d.ts
+++ b/src/core/components/range/range.d.ts
@@ -23,7 +23,7 @@ export namespace Range {
     draggableBar?: boolean
     /** Object with events handlers.. */
     on?: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
   }
   interface Range extends Framework7EventsClass<Events> {

--- a/src/core/components/searchbar/searchbar.d.ts
+++ b/src/core/components/searchbar/searchbar.d.ts
@@ -45,7 +45,7 @@ export namespace Searchbar {
     expandable?: boolean
     /** Object with events handlers.. */
     on?: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
   }
   interface Searchbar extends Framework7EventsClass<Events> {

--- a/src/core/components/sheet/sheet.d.ts
+++ b/src/core/components/sheet/sheet.d.ts
@@ -32,7 +32,7 @@ export namespace Sheet {
 
     /** Object with events handlers.. */
     on?: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
   }
   interface Sheet extends Framework7EventsClass<Events> {

--- a/src/core/components/smart-select/smart-select.d.ts
+++ b/src/core/components/smart-select/smart-select.d.ts
@@ -77,7 +77,7 @@ export namespace SmartSelect {
 
     /** Object with events handlers.. */
     on?: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
   }
   interface SmartSelect extends Framework7EventsClass<Events> {

--- a/src/core/components/sortable/sortable.d.ts
+++ b/src/core/components/sortable/sortable.d.ts
@@ -7,11 +7,11 @@ export namespace Sortable {
   }
   interface DomEvents {
     /** Event will be triggered when sortable mode is enabled */
-    'sortable:enable': (Event) => void
+    'sortable:enable': (event: any) => void
     /** Event will be triggered when sortable mode is disabled */
-    'sortable:disable': (Event) => void
+    'sortable:disable': (event: any) => void
     /** Event will be triggered after user release currently sorting element in new position. event.detail will contain object with from and to properties with from/to index numbers of sorted list item */
-    'sortable:sort': (Event, indexes: SortIndexes) => void
+    'sortable:sort': (event: any, indexes: SortIndexes) => void
   }
   interface AppMethods {
     sortable: {

--- a/src/core/components/stepper/stepper.d.ts
+++ b/src/core/components/stepper/stepper.d.ts
@@ -33,7 +33,7 @@ export namespace Stepper {
     buttonsEndInputMode?: boolean
     /** Object with events handlers.. */
     on?: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
   }
   interface Stepper extends Framework7EventsClass<Events> {

--- a/src/core/components/swipeout/swipeout.d.ts
+++ b/src/core/components/swipeout/swipeout.d.ts
@@ -3,19 +3,19 @@ import { CSSSelector, Framework7Plugin } from '../app/app-class';
 export namespace Swipeout {
   interface DomEvents {
     /** Event will be triggered while you move swipeout element. event.detail contains current opening progress percentage */
-    'swipeout': (Event) => void
+    'swipeout': (event: any) => void
     /** Event will be triggered when swipeout element starts its opening animation */
-    'swipeout:open': (Event) => void
+    'swipeout:open': (event: any) => void
     /** Event will be triggered after swipeout element completes its opening animation */
-    'swipeout:opened': (Event) => void
+    'swipeout:opened': (event: any) => void
     /** Event will be triggered when swipeout element starts its closing animation */
-    'swipeout:close': (Event) => void
+    'swipeout:close': (event: any) => void
     /** Event will be triggered after swipeout element completes its closing animation */
-    'swipeout:closed': (Event) => void
+    'swipeout:closed': (event: any) => void
     /** Event will be triggered after swipeout element starts its delete animation */
-    'swipeout:delete': (Event) => void
+    'swipeout:delete': (event: any) => void
     /** Event will be triggered after swipeout element completes its delete animation right before it will be removed from DOM */
-    'swipeout:deleted': (Event) => void
+    'swipeout:deleted': (event: any) => void
   }
   interface AppMethods {
     swipeout: {

--- a/src/core/components/tabs/tabs.d.ts
+++ b/src/core/components/tabs/tabs.d.ts
@@ -9,9 +9,9 @@ export namespace Tabs {
   }
   interface DomEvents {
     /** Event will be triggered when Tab becomes visible/active */
-    'tab:show': (Event) => void
+    'tab:show': (event: any) => void
     /** Event will be triggered when Tab becomes hidden/inactive */
-    'tab:hide': (Event) => void
+    'tab:hide': (event: any) => void
   }
   interface AppMethods {
     tab: {

--- a/src/core/components/toast/toast.d.ts
+++ b/src/core/components/toast/toast.d.ts
@@ -40,7 +40,7 @@ export namespace Toast {
 
     /** Object with events handlers.. */
     on?: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
   }
   interface Toast extends Framework7EventsClass<Events> {

--- a/src/core/components/toggle/toggle.d.ts
+++ b/src/core/components/toggle/toggle.d.ts
@@ -7,7 +7,7 @@ export namespace Toggle {
     el?: HTMLElement | CSSSelector
     /** Object with events handlers.. */
     on?: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
   }
   interface Toggle extends Framework7EventsClass<Events> {

--- a/src/core/components/tooltip/tooltip.d.ts
+++ b/src/core/components/tooltip/tooltip.d.ts
@@ -13,7 +13,7 @@ export namespace Tooltip {
     render?: (tooltip: Tooltip) => string
     /** Object with events handlers.. */
     on?: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
   }
   interface DomEvents {

--- a/src/core/components/vi/vi.d.ts
+++ b/src/core/components/vi/vi.d.ts
@@ -80,7 +80,7 @@ export namespace Vi {
     connectionProvider?: string
     /** Object with events handlers.. */
     on?: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
   }
   interface Events {

--- a/src/core/components/view/view.d.ts
+++ b/src/core/components/view/view.d.ts
@@ -121,7 +121,7 @@ export namespace View {
     pushStateOnLoad?: boolean
     /** Object with events handlers.. */
     on?: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
   }
   interface View extends Router.AppMethods{}

--- a/src/core/components/virtual-list/virtual-list.d.ts
+++ b/src/core/components/virtual-list/virtual-list.d.ts
@@ -106,7 +106,7 @@ export namespace VirtualList {
     searchAll?(query: string, items: any[]): any[]
     /** Object with events handlers.. */
     on?: {
-      [event in keyof Events] : Events[event]
+      [event in keyof Events]? : Events[event]
     }
   }
   interface Events {

--- a/src/core/utils/request.d.ts
+++ b/src/core/utils/request.d.ts
@@ -80,7 +80,7 @@ export interface Request {
     url: string,
     data?: any,
     success?: (data: any, status: number | string, xhr: RequestXHR) => void,
-    error: (xhr: RequestXHR, status: number | string) => void,
+    error?: (xhr: RequestXHR, status: number | string) => void,
     dataType?: string
   ) => RequestXHR
   /** Set default values for future Ajax requests */

--- a/src/core/utils/utils.d.ts
+++ b/src/core/utils/utils.d.ts
@@ -16,9 +16,9 @@ export interface Utils {
   /** Returns current timestamp in ms */
   now: () => number
   /** Extends target object with properties and methods from from objects */
-  extend: (target: object, ...from: object) => object
+  extend: (target: object, ...from: object[]) => object
   /** Extends target object with properties and methods from from objects */
-  merge: (target: object, ...from: object) => object
+  merge: (target: object, ...from: object[]) => object
   /** Returns unique number, increased by 1 with every call */
   uniqueNumber: () => number
   /** Generates random ID-like string */


### PR DESCRIPTION
It doesn't seem like framework7 and framework7-react were compiling under TypeScript 3.0.1. Looking at the problems, it doesn't seem to me that they were compiling under any version of TypeScript, but I haven't confirmed that.

These changes aim to fix that. I have a project that is compiling successfully with these changes plus https://github.com/phenomejs/phenome/pull/40.

Ideally, we'd at least add a smoke test that just imports framework7 and framework7-react from a TypeScript file and makes sure that it compiles.

Related: https://github.com/phenomejs/phenome/issues/11