### PR TITLE
Pass options.route instead of route to async handler

### DIFF
--- a/src/core/modules/router/navigate.js
+++ b/src/core/modules/router/navigate.js
@@ -645,7 +645,7 @@ function navigate(navigateParams, navigateOptions = {}) {
     if (route.route.async) {
       router.allowPageChange = false;
 
-      route.route.async.call(router, route, router.currentRoute, asyncResolve, asyncReject);
+      route.route.async.call(router, options.route, router.currentRoute, asyncResolve, asyncReject);
     }
   }
   function reject() {


### PR DESCRIPTION
In router.navigate, an object is created with the route data being navigated to and stored in `route` variable. A shallow copy of it is stored in `options.route`. Both store the same info.

Currently the `route` variable is passed to route async handler as `to` param, but the `router.load` (called in `asyncResolve`) uses options.route instead which will be stored as `router.currentRoute`

With this PR the `to` param passed to route async handler will be the same instance that will become `router.currentRoute` and in subsequent route navigation will be passed as `from` param.

This allow to, e.g., store related data and retrieve later in async handlers as done [here](https://github.com/blikblum/marionette.f7/blob/master/src/asyncroute.js#L98) and [here](mnRouteMap).



