### PR TITLE
Fix bug Accordion on iOS 9 (using nextFrame function)

### DIFF
--- a/packages/core/components/accordion/accordion.js
+++ b/packages/core/components/accordion/accordion.js
@@ -34,10 +34,9 @@ const Accordion = {
         $contentEl.css('height', 'auto');
         Utils.nextFrame(() => {
           $contentEl.transition('');
+          $el.trigger('accordion:opened');
+          app.emit('accordionOpened', $el[0]);
         });
-        $contentEl.transition('');
-        $el.trigger('accordion:opened');
-        app.emit('accordionOpened', $el[0]);
       } else {
         $contentEl.css('height', '');
         $el.trigger('accordion:closed');
@@ -65,9 +64,9 @@ const Accordion = {
         $contentEl.css('height', 'auto');
         Utils.nextFrame(() => {
           $contentEl.transition('');
+          $el.trigger('accordion:opened');
+          app.emit('accordionOpened', $el[0]);
         });
-        $el.trigger('accordion:opened');
-        app.emit('accordionOpened', $el[0]);
       } else {
         $contentEl.css('height', '');
         $el.trigger('accordion:closed');


### PR DESCRIPTION
Fix the bug when opening the accordion on iOS 9 using the function `nextFrame`.

Thank you Vladimir.
