### PR TITLE
Do not clone deep options in forward

### DIFF
--- a/src/core/modules/router/navigate.js
+++ b/src/core/modules/router/navigate.js
@@ -18,7 +18,7 @@ function forward(el, forwardOptions = {}) {
   const app = router.app;
   const view = router.view;
 
-  const options = Utils.extend({
+  const options = Utils.extend(false, {
     animate: router.params.animate,
     pushState: true,
     replaceState: false,


### PR DESCRIPTION
This is a followup to #2713.

In the process of cloning options in forward function, the the route instance is replaced by a copy, so the route instance stored in `router.currentRoute` is different from the one passed to route async handler. 

The proposed change is safe since `options` variable is not mutated at all.

It is also more performant


