### PR TITLE
Prevent smartSelect to be rendered twice

### DIFF
--- a/src/phenome/components/link.jsx
+++ b/src/phenome/components/link.jsx
@@ -236,10 +236,6 @@ export default {
   },
   methods: {
     onClick(event) {
-      const self = this;
-      if (self.props.smartSelect && self.f7SmartSelect) {
-        self.f7SmartSelect.open();
-      }
       this.dispatchEvent('click', event);
     },
   },


### PR DESCRIPTION
This change is similar to what you did in https://github.com/framework7io/framework7/commit/1973c08ed99db3848ee943740bb2e5e656a15a17

Currently smartSelect attached to link renders two popups on link click.