### PR TITLE
Implement clearDomCache method in the Router

### DIFF
--- a/src/core/modules/router/clear-previous-history.js
+++ b/src/core/modules/router/clear-previous-history.js
@@ -1,6 +1,6 @@
 import $ from 'dom7';
 
-function clearDomCache() {
+function clearStackedPages() {
   const router = this;
   const app = router.app;
   const separateNavbar = router.separateNavbar;
@@ -8,7 +8,7 @@ function clearDomCache() {
   const $currentPageEl = $(router.currentPageEl);
 
   const $pagesToRemove = router.$el
-    .children('.page:not(.stacked)')
+    .children('.page')
     .filter((index, pageInView) => pageInView !== $currentPageEl[0]);
 
   $pagesToRemove.each((index, pageEl) => {
@@ -34,11 +34,11 @@ function clearPreviousHistory() {
   const router = this;
   const url = router.history[router.history.length - 1];
 
-  router.clearDomCache();
+  router.clearStackedPages();
 
   router.history = [url];
   router.view.history = [url];
   router.saveHistory();
 }
 
-export { clearPreviousHistory, clearDomCache }; // eslint-disable-line
+export { clearPreviousHistory, clearStackedPages }; // eslint-disable-line

--- a/src/core/modules/router/clear-previous-history.js
+++ b/src/core/modules/router/clear-previous-history.js
@@ -1,6 +1,6 @@
 import $ from 'dom7';
 
-function clearStackedPages() {
+function clearPreviousPages() {
   const router = this;
   const app = router.app;
   const separateNavbar = router.separateNavbar;
@@ -34,11 +34,11 @@ function clearPreviousHistory() {
   const router = this;
   const url = router.history[router.history.length - 1];
 
-  router.clearStackedPages();
+  router.clearPreviousPages();
 
   router.history = [url];
   router.view.history = [url];
   router.saveHistory();
 }
 
-export { clearPreviousHistory, clearStackedPages }; // eslint-disable-line
+export { clearPreviousHistory, clearPreviousPages }; // eslint-disable-line

--- a/src/core/modules/router/clear-previous-history.js
+++ b/src/core/modules/router/clear-previous-history.js
@@ -1,10 +1,9 @@
 import $ from 'dom7';
 
-function clearPreviousHistory() {
+function clearDomCache() {
   const router = this;
   const app = router.app;
   const separateNavbar = router.separateNavbar;
-  const url = router.history[router.history.length - 1];
 
   const $currentPageEl = $(router.currentPageEl);
 
@@ -29,10 +28,17 @@ function clearPreviousHistory() {
       }
     }
   });
+}
+
+function clearPreviousHistory() {
+  const router = this;
+  const url = router.history[router.history.length - 1];
+
+  router.clearDomCache();
 
   router.history = [url];
   router.view.history = [url];
   router.saveHistory();
 }
 
-export { clearPreviousHistory }; // eslint-disable-line
+export { clearPreviousHistory, clearDomCache }; // eslint-disable-line

--- a/src/core/modules/router/router-class.js
+++ b/src/core/modules/router/router-class.js
@@ -11,7 +11,7 @@ import { refreshPage, forward, load, navigate } from './navigate';
 import { tabLoad, tabRemove } from './tab';
 import { modalLoad, modalRemove } from './modal';
 import { backward, loadBack, back } from './back';
-import { clearPreviousHistory, clearDomCache } from './clear-previous-history';
+import { clearPreviousHistory, clearStackedPages } from './clear-previous-history';
 
 class Router extends Framework7Class {
   constructor(app, view) {
@@ -1362,8 +1362,8 @@ Router.prototype.modalRemove = modalRemove;
 Router.prototype.backward = backward;
 Router.prototype.loadBack = loadBack;
 Router.prototype.back = back;
-// Clear Dom cache
-Router.prototype.clearDomCache = clearDomCache;
+// Clear stacked pages
+Router.prototype.clearStackedPages = clearStackedPages;
 // Clear history
 Router.prototype.clearPreviousHistory = clearPreviousHistory;
 

--- a/src/core/modules/router/router-class.js
+++ b/src/core/modules/router/router-class.js
@@ -11,7 +11,7 @@ import { refreshPage, forward, load, navigate } from './navigate';
 import { tabLoad, tabRemove } from './tab';
 import { modalLoad, modalRemove } from './modal';
 import { backward, loadBack, back } from './back';
-import { clearPreviousHistory } from './clear-previous-history';
+import { clearPreviousHistory, clearDomCache } from './clear-previous-history';
 
 class Router extends Framework7Class {
   constructor(app, view) {
@@ -1362,6 +1362,8 @@ Router.prototype.modalRemove = modalRemove;
 Router.prototype.backward = backward;
 Router.prototype.loadBack = loadBack;
 Router.prototype.back = back;
+// Clear Dom cache
+Router.prototype.clearDomCache = clearDomCache;
 // Clear history
 Router.prototype.clearPreviousHistory = clearPreviousHistory;
 

--- a/src/core/modules/router/router-class.js
+++ b/src/core/modules/router/router-class.js
@@ -11,7 +11,7 @@ import { refreshPage, forward, load, navigate } from './navigate';
 import { tabLoad, tabRemove } from './tab';
 import { modalLoad, modalRemove } from './modal';
 import { backward, loadBack, back } from './back';
-import { clearPreviousHistory, clearStackedPages } from './clear-previous-history';
+import { clearPreviousHistory, clearPreviousPages } from './clear-previous-history';
 
 class Router extends Framework7Class {
   constructor(app, view) {
@@ -1362,8 +1362,8 @@ Router.prototype.modalRemove = modalRemove;
 Router.prototype.backward = backward;
 Router.prototype.loadBack = loadBack;
 Router.prototype.back = back;
-// Clear stacked pages
-Router.prototype.clearStackedPages = clearStackedPages;
+// Clear previoius pages from the DOM
+Router.prototype.clearPreviousPages = clearPreviousPages;
 // Clear history
 Router.prototype.clearPreviousHistory = clearPreviousHistory;
 

--- a/src/core/modules/router/router.d.ts
+++ b/src/core/modules/router/router.d.ts
@@ -201,7 +201,7 @@ export namespace Router {
     /** Refresh/reload current page */
     refreshPage(): Router
     /** Remove all previous pages from DOM */
-    clearDomCache(): Router
+    clearStackedPages(): Router
     /** Clear router previous pages history and remove all previous pages from DOM */
     clearPreviousHistory(): Router
     /** Updates current route url, and updates `router.currentRoute` properties (query, params, hash, etc.) based on passed url. This method doesn't load or reload any content. It just changes current route url */

--- a/src/core/modules/router/router.d.ts
+++ b/src/core/modules/router/router.d.ts
@@ -201,7 +201,7 @@ export namespace Router {
     /** Refresh/reload current page */
     refreshPage(): Router
     /** Remove all previous pages from DOM */
-    clearStackedPages(): Router
+    clearPreviousPages(): Router
     /** Clear router previous pages history and remove all previous pages from DOM */
     clearPreviousHistory(): Router
     /** Updates current route url, and updates `router.currentRoute` properties (query, params, hash, etc.) based on passed url. This method doesn't load or reload any content. It just changes current route url */

--- a/src/core/modules/router/router.d.ts
+++ b/src/core/modules/router/router.d.ts
@@ -200,6 +200,8 @@ export namespace Router {
     back(url?: string, options?: RouteOptions): Router
     /** Refresh/reload current page */
     refreshPage(): Router
+    /** Remove all previous pages from DOM */
+    clearDomCache(): Router
     /** Clear router previous pages history and remove all previous pages from DOM */
     clearPreviousHistory(): Router
     /** Updates current route url, and updates `router.currentRoute` properties (query, params, hash, etc.) based on passed url. This method doesn't load or reload any content. It just changes current route url */


### PR DESCRIPTION
Factor out the Dom cache clearing from clearPreviousHistory(), and export it as a Router method.

See https://github.com/framework7io/framework7/issues/2841

This facilitates a use case like chaning language preference, where you can refreshPage() to reload the current page in the current language, and then call clearDomCache() to ensure that pages in the history will be reloaded in the current language if they are revisited.

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/framework7io/framework7/blob/master/.github/CONTRIBUTING.md) when submitting a pull request.
