### PR TITLE
bind full event object instead of prevent() reference only

### DIFF
--- a/src/phenome/components/accordion-item.jsx
+++ b/src/phenome/components/accordion-item.jsx
@@ -65,7 +65,7 @@ export default {
   },
   methods: {
     onBeforeOpen(event) {
-      this.dispatchEvent('accordionBeforeOpen accordion:beforeopen', event.detail.prevent);
+      this.dispatchEvent('accordionBeforeOpen accordion:beforeopen', event);
     },
     onOpen(event) {
       this.dispatchEvent('accordionOpen accordion:open', event);
@@ -74,7 +74,7 @@ export default {
       this.dispatchEvent('accordionOpened accordion:opened', event);
     },
     onBeforeClose(event) {
-      this.dispatchEvent('accordionBeforeClose accordion:beforeclose', event.detail.prevent);
+      this.dispatchEvent('accordionBeforeClose accordion:beforeclose', event);
     },
     onClose(event) {
       this.dispatchEvent('accordionClose accordion:close', event);

--- a/src/phenome/components/list-item.jsx
+++ b/src/phenome/components/list-item.jsx
@@ -425,7 +425,7 @@ export default {
       this.dispatchEvent('swipeout', event);
     },
     onAccBeforeClose(event) {
-      this.dispatchEvent('accordion:beforeclose accordionBeforeClose', event.detail.prevent);
+      this.dispatchEvent('accordion:beforeclose accordionBeforeClose', event);
     },
     onAccClose(event) {
       this.dispatchEvent('accordion:close accordionClose', event);
@@ -434,7 +434,7 @@ export default {
       this.dispatchEvent('accordion:closed accordionClosed', event);
     },
     onAccBeforeOpen(event) {
-      this.dispatchEvent('accordion:beforeopen accordionBeforeOpen', event.detail.prevent);
+      this.dispatchEvent('accordion:beforeopen accordionBeforeOpen', event);
     },
     onAccOpen(event) {
       this.dispatchEvent('accordion:open accordionOpen', event);


### PR DESCRIPTION
Bind full event object to beforeOpen and beforeClose events in accordion-item and list-item phenome component to make prevent() actually useful.