### PR TITLE
Browser field in package.json

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,6 +3,7 @@
   "version": "3.5.2",
   "description": "Full featured mobile HTML framework for building iOS & Android apps",
   "main": "js/framework7.js",
+  "browser": "js/framework7.js",
   "typings": "framework7.d.ts",
   "jsnext:main": "framework7.esm.js",
   "module": "framework7.esm.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -3,6 +3,7 @@
   "version": "3.5.2",
   "description": "Build full featured iOS & Android apps using Framework7 & React",
   "main": "framework7-react.js",
+  "browser": "framework7-react.js",
   "typings": "framework7-react.d.ts",
   "jsnext:main": "framework7-react.esm.js",
   "module": "framework7-react.esm.js",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -3,6 +3,7 @@
   "version": "3.5.2",
   "description": "Build full featured iOS & Android apps using Framework7 & Vue",
   "main": "framework7-vue.js",
+  "browser": "framework7-vue.js",
   "jsnext:main": "framework7-vue.esm.js",
   "module": "framework7-vue.esm.js",
   "scripts": {


### PR DESCRIPTION
Webpack has `mainFields` option to resolve modules.
https://webpack.js.org/configuration/resolve/#resolve-mainfields

By default it is `['browser', 'module', 'main']`,  so `module` has more priority than `main`. 
Obviously, for web and mobile devices es5 is more preferably (iPhone 5 @ ios 10, Android < 5), so in order not to change the configuration of webpack, I suggest to add `browser` field same as `main`.