### PR TITLE
[Kitchen Sink] Icons with a long name cause overflow problems

### DIFF
--- a/kitchen-sink/core/css/app.css
+++ b/kitchen-sink/core/css/app.css
@@ -458,6 +458,8 @@ code {
   margin-top: 5px;
   font-size: 11px;
   color: #666;
+  text-overflow: ellipsis;
+  overflow: hidden;
 }
 .theme-dark .demo-icon .demo-icon-name {
   color: #aaa;

--- a/kitchen-sink/react/css/app.css
+++ b/kitchen-sink/react/css/app.css
@@ -461,6 +461,8 @@ code {
   margin-top: 5px;
   font-size: 11px;
   color: #666;
+  text-overflow: ellipsis;
+  overflow: hidden;
 }
 .theme-dark .demo-icon .demo-icon-name {
   color: #aaa;

--- a/kitchen-sink/vue/css/app.css
+++ b/kitchen-sink/vue/css/app.css
@@ -461,6 +461,8 @@ code {
   margin-top: 5px;
   font-size: 11px;
   color: #666;
+  text-overflow: ellipsis;
+  overflow: hidden;
 }
 .theme-dark .demo-icon .demo-icon-name {
   color: #aaa;


### PR DESCRIPTION
The long name of some icons causes overflow problems in the Demo Page of Icons on devices that have a small screen