### PR TITLE
Неправильное значение параметра по умолчанию

### DIFF
--- a/src/core/components/popover/popover.js
+++ b/src/core/components/popover/popover.js
@@ -8,7 +8,7 @@ export default {
   params: {
     popover: {
       closeByBackdropClick: true,
-      closeByOutsideClick: false,
+      closeByOutsideClick: true,
       backdrop: true,
     },
   },


### PR DESCRIPTION
Согласно https://framework7.io/docs/popover.html#popover-parameters параметр должен иметь значение 'true", так и более логично.

