### PR TITLE
v4: Toast - Small typo

### DIFF
--- a/src/core/components/toast/toast.less
+++ b/src/core/components/toast/toast.less
@@ -51,7 +51,7 @@
   &.toast-center {
     top: 50%;
   }
-  &.toat-top {
+  &.toast-top {
     margin-top: var(--f7-statusbar-height);
   }
 }


### PR DESCRIPTION
Toast - Small typo:

&.toat-top ->  &.toast-top