### PR TITLE
added overload to Framework7.use for array of plugins

### DIFF
--- a/src/core/components/app/app-class.d.ts
+++ b/src/core/components/app/app-class.d.ts
@@ -153,6 +153,7 @@ declare class Framework7 implements Framework7 {
   constructor(parameters?: Framework7Params);
 
   static use(plugin : Framework7Plugin) : void;
+  static use(plugins : Framework7Plugin[]) : void;
   static device: Device;
   static request: Request;
   static support: Support;


### PR DESCRIPTION
Framework7.use can accept an array of plugins, but `app-class.d.ts` only specifies a single one. 

This is a change to rectify that.
