### PR TITLE
[KS] Long $route.params causes overflow problems

### DIFF
--- a/kitchen-sink/core/pages/page-loader-component.html
+++ b/kitchen-sink/core/pages/page-loader-component.html
@@ -42,7 +42,7 @@
         <p>Component page context as Template7 page context is also extended with some additional variables.</p>
         <h4>$route</h4>
         <p>Contains properties of the current route:</p>
-        <ul style="padding-left:25px">
+        <ul style="padding-left:25px;word-wrap:break-word;">
           <li><b>$route.url</b>: {{$route.url}}</li>
           <li><b>$route.path</b>: {{$route.path}}</li>
           <li><b>$route.params</b>: {{js 'return JSON.stringify(this.$route.params)'}}</li>

--- a/kitchen-sink/core/pages/page-loader-template7.html
+++ b/kitchen-sink/core/pages/page-loader-template7.html
@@ -27,7 +27,7 @@
 
       <h4>$route</h4>
       <p>Contains properties of the current route:</p>
-      <ul style="padding-left:25px">
+      <ul style="padding-left:25px;word-wrap:break-word;">
         <li><b>$route.url</b>: {{$route.url}}</li>
         <li><b>$route.path</b>: {{$route.path}}</li>
         <li><b>$route.params</b>: {{js 'return JSON.stringify(this.$route.params)'}}</li>


### PR DESCRIPTION
The long strings ($route.params) causes overflow problems in the Page Loaders examples (Template7 Page and Component Page) on devices that have a small screen