### PR TITLE
Fix compile error in Typescript Strict Mode

### DIFF
--- a/src/core/modules/router/router.d.ts
+++ b/src/core/modules/router/router.d.ts
@@ -13,7 +13,7 @@ export namespace Router {
     /** Component CSS styles. Styles will be added to the document after component will be mounted (added to DOM), and removed after component will be destroyed (removed from the DOM) */
     style? : string
     /** Object with additional component methods which extend component context */
-    methods? : { [name : string] : (...args) => any }
+    methods? : { [name : string] : (...args: any) => any }
     /** Object with page events handlers */
     on? : { [event : string] : (e: Event, page: any) => void }
 


### PR DESCRIPTION
If typescript is in strict mode everything needs to be typed explicitly. In Line 16 of this file there was one occurrence where that was not the case which leads to the following error:
```
ERROR in [at-loader] ./node_modules/framework7/modules/router/router.d.ts:16:37
    TS7019: Rest parameter 'args' implicitly has an 'any[]' type.
```
