### PR TITLE
typing fixes

### DIFF
--- a/packages/core/components/dialog/dialog.d.ts
+++ b/packages/core/components/dialog/dialog.d.ts
@@ -178,6 +178,8 @@ export namespace Dialog {
       destroyPredefinedDialogs?: boolean
       /** Enables keyboard shortcuts (Enter and Esc) keys for predefined dialogs (Alert, Confirm, Prompt, Login, Password) "Ok" and "Cancel" buttons. (default true) */
       keyboardActions?: boolean
+      /** When enabled, dialog will be closed on backdrop click. (default true) */
+      closeByBackdropClick?: boolean;
     } | undefined
   }
   interface AppEvents {

--- a/packages/core/components/tooltip/tooltip.d.ts
+++ b/packages/core/components/tooltip/tooltip.d.ts
@@ -59,7 +59,7 @@ export namespace Tooltip {
     destroy(): void
   }
   interface AppMethods {
-    tootlip: {
+    tooltip: {
       /** create Tooltip instance */
       create(parameters: Parameters): Tooltip
       /** destroy Tooltip instance */

--- a/src/core/components/autocomplete/autocomplete.d.ts
+++ b/src/core/components/autocomplete/autocomplete.d.ts
@@ -50,7 +50,7 @@ export namespace Autocomplete {
     /** Defines how to open Autocomplete, can be page or popup (for Standalone) or dropdown. (default page) */
     openIn?: string
     /** Function which accepts search query and render function where you need to pass array with matched items. */
-    source: (query : string, render : unknown[]) => unknown
+    source: (query : string, render : (items: unknown[]) => void) => void
     /** Limit number of maximum displayed items in autocomplete per query. */
     limit?: number
     /** Set to true to include Preloader to autocomplete layout. (default false) */
@@ -133,7 +133,7 @@ export namespace Autocomplete {
 
   interface Events {
     /** Event will be triggered when Autocomplete value changed. Returned value is an array with selected items */
-    change : (autocomplete : Autocomplete, value : unknown) => void
+    change : (values : unknown[]) => void
     /** Event will be triggered when Autocomplete starts its opening animation. As an argument event handler receives autocomplete instance */
     open : (autocomplete : Autocomplete) => void
     /** Event will be triggered after Autocomplete completes its opening animation. As an argument event handler receives autocomplete instance */


### PR DESCRIPTION
Fixed some typing mistakes:

1. Added missing dialog.closeByBackdropClick.
2. Fixed tooltip typo (was tootlip).
3. Fixed two autocomplete param function signatures.
