### PR TITLE
Убран дополнительный вертикальный отступ в MD-тема, который создает pull to refresh в page-content

### DIFF
--- a/src/core/components/pull-to-refresh/pull-to-refresh-md.less
+++ b/src/core/components/pull-to-refresh/pull-to-refresh-md.less
@@ -5,7 +5,7 @@
     border-radius: 50%;
     background: #fff;
     margin-left: calc(-1 * var(--f7-ptr-size) / 2);
-    margin-top: calc(-1 * var(--f7-ptr-size) - 4px);
+    margin-top: calc(-1 * var(--f7-ptr-size));
     z-index: 100;
     box-shadow: var(--f7-elevation-1);
     .preloader {

--- a/src/core/components/pull-to-refresh/pull-to-refresh-vars.less
+++ b/src/core/components/pull-to-refresh/pull-to-refresh-vars.less
@@ -8,4 +8,5 @@
 .md {
   --f7-ptr-preloader-size: 22px;
   --f7-ptr-size: 40px;
+  --f7-ptr-top: -4px;
 }

--- a/src/core/components/pull-to-refresh/pull-to-refresh.less
+++ b/src/core/components/pull-to-refresh/pull-to-refresh.less
@@ -3,7 +3,7 @@
 
 .ptr-preloader {
   position: relative;
-  top: var(--f7-ptr-top);
+  top: var(--f7-ptr-top, 0);
   height: var(--f7-ptr-size);
   .preloader {
     position: absolute;

--- a/src/core/components/pull-to-refresh/pull-to-refresh.less
+++ b/src/core/components/pull-to-refresh/pull-to-refresh.less
@@ -3,7 +3,7 @@
 
 .ptr-preloader {
   position: relative;
-  top: 0;
+  top: var(--f7-ptr-top);
   height: var(--f7-ptr-size);
   .preloader {
     position: absolute;


### PR DESCRIPTION
При добавлении Pull To Refresh в HTML, как написано в документации:
```
     <div class="page-content ptr-content">
            <div class="ptr-preloader">
                <div class="preloader"></div>
                <div class="ptr-arrow"></div>
            </div>
     ....
```

в MD-теме возникает дополнительный вертикальный отступ у всего контента, который находится в page-content. Я набросал код, который решает проблему.
