### PR TITLE
Remove webkit prefix for animation properties and events

### DIFF
--- a/src/core/components/tooltip/tooltip-class.js
+++ b/src/core/components/tooltip/tooltip-class.js
@@ -79,7 +79,7 @@ class Tooltip extends Framework7Class {
     }
 
     tooltip.attachEvents = function attachEvents() {
-      $el.on('transitionend webkitTransitionEnd', handleTransitionEnd);
+      $el.on('transitionend', handleTransitionEnd);
       if (Support.touch) {
         const passive = Support.passiveListener ? { passive: true } : false;
         $targetEl.on(app.touchEvents.start, handleTouchStart, passive);
@@ -91,7 +91,7 @@ class Tooltip extends Framework7Class {
       }
     };
     tooltip.detachEvents = function detachEvents() {
-      $el.off('transitionend webkitTransitionEnd', handleTransitionEnd);
+      $el.off('transitionend', handleTransitionEnd);
       if (Support.touch) {
         const passive = Support.passiveListener ? { passive: true } : false;
         $targetEl.off(app.touchEvents.start, handleTouchStart, passive);

--- a/src/core/utils/utils.js
+++ b/src/core/utils/utils.js
@@ -167,14 +167,10 @@ const Utils = {
     return Date.now();
   },
   requestAnimationFrame(callback) {
-    if (window.requestAnimationFrame) return window.requestAnimationFrame(callback);
-    if (window.webkitRequestAnimationFrame) return window.webkitRequestAnimationFrame(callback);
-    return window.setTimeout(callback, 1000 / 60);
+    return window.requestAnimationFrame(callback);
   },
   cancelAnimationFrame(id) {
-    if (window.cancelAnimationFrame) return window.cancelAnimationFrame(id);
-    if (window.webkitCancelAnimationFrame) return window.webkitCancelAnimationFrame(id);
-    return window.clearTimeout(id);
+    return window.cancelAnimationFrame(id);
   },
   removeDiacritics(str) {
     return str.replace(/[^\u0000-\u007E]/g, a => diacriticsMap[a] || a);


### PR DESCRIPTION
Removes webkit prefixes for animation properties and events. It simplifies code, reducing number of registered events

All supported browsers in upcoming v4 supports unprefixed versions

Keeps WebKitCSSMatrix since the standard DOMMatrix is not widely supported. Also kept the support checks