### PR TITLE
Little typing fix that caused app-class.d.ts to not be accepted by Typescript compiler

### DIFF
--- a/src/core/components/app/app-class.d.ts
+++ b/src/core/components/app/app-class.d.ts
@@ -148,7 +148,7 @@ interface Framework7 extends Framework7Class<Framework7Events> {
   /** Load modules */
   loadModules(modules: any[]) : Promise<any>
 }
-interface Events extends Framework7EventsClass {}
+interface Events extends Framework7EventsClass<Framework7Events> {}
 
 declare class Framework7 implements Framework7 {
   constructor(parameters?: Framework7Params);


### PR DESCRIPTION
Basically, after working on the PR for #3005, I observed the code still not compiled, but now because of the following error: 

```
[at-loader] ./node_modules/framework7/components/app/app-class.d.ts:151:26 
    TS2314: Generic type 'Framework7EventsClass<Events>' requires 1 type argument(s). 
```

This PR fixes this error.