### PR TITLE
Fix helper's import path in .d.ts file that was missing on PR #3006

### DIFF
--- a/scripts/build-core-typings.js
+++ b/scripts/build-core-typings.js
@@ -17,6 +17,17 @@ function capitalize(name) {
 }
 
 function generateTypings(basePath, modules, components) {
+  const f7Base = `import Framework7 from '${basePath}/components/app/app-class'`;
+
+  const helpers = ['request', 'utils', 'support', 'device'];
+
+  const importHelpers = helpers.map((helper) => {
+    const capitalized = capitalize(helper);
+    return `import ${capitalized} from '${basePath}/utils/${helper}';`;
+  });
+
+  const exportHelpers = helpers.map(capitalize).join(', ');
+
   const importModules = modules.map((f7Module) => {
     const capitalized = capitalize(f7Module);
     return `import {${capitalized} as ${capitalized}Namespace} from '${basePath}/modules/${f7Module}/${f7Module}';`;
@@ -37,6 +48,9 @@ function generateTypings(basePath, modules, components) {
   });
 
   return fs.readFileSync(path.resolve(__dirname, '../src/core/framework7.d.ts'))
+    .replace(/\/\/ IMPORT_BASE/, f7Base)
+    .replace(/\/\/ IMPORT_HELPERS/, importHelpers.join('\n'))
+    .replace(/\/\/ EXPORT_HELPERS/, `export { ${exportHelpers} };`)
     .replace(/\/\/ IMPORT_MODULES/, importModules.join('\n'))
     .replace(/\/\/ IMPORT_COMPONENTS/, importComponents.join('\n'))
     .replace(/\/\/ INSTALL/, install.join('\n  '));

--- a/src/core/framework7.d.ts
+++ b/src/core/framework7.d.ts
@@ -1,12 +1,9 @@
 import Template7 from 'template7';
 import Dom7 from 'dom7';
-import Framework7 from './components/app/app-class';
+// IMPORT_BASE
 
 // Helpers
-import Request from './utils/request';
-import Utils from './utils/utils';
-import Support from './utils/support';
-import Device from './utils/device';
+// IMPORT_HELPERS
 
 // Modules
 // IMPORT_MODULES
@@ -18,5 +15,6 @@ declare module './components/app/app-class' {
   // INSTALL
 }
 
-export { Request, Utils, Support, Device, Template7, Dom7 };
+// EXPORT_HELPERS
+export { Template7, Dom7 };
 export default Framework7;


### PR DESCRIPTION
Hey.

Seems like I forgot to update a few paths (specifically, those from the utils folder and from the `components/app` folder, and because of this #3005 was still happening here.

Because of this I'm sending this new PR, intended as a continuation to #3006. I migrated most of the code in the base `framework7.d.ts` file to `build-core-typings` based on this. Sorry for all the trouble. :(

