### PR TITLE
Added missing calc() in .md .searchbar-expandable css-class (syntax error fix)

### DIFF
--- a/src/core/components/searchbar/searchbar-md.less
+++ b/src/core/components/searchbar/searchbar-md.less
@@ -75,7 +75,7 @@
   .page > .searchbar,
   .subnavbar .searchbar,
   .searchbar-expandable {
-    --f7-searchbar-input-extra-padding-left: 17px + 8px;
+    --f7-searchbar-input-extra-padding-left: calc(17px + 8px);
     .searchbar-icon, .searchbar-disable-button {
       .ltr({
         left: calc(-4px + 8px + var(--f7-safe-area-left));


### PR DESCRIPTION
calc() is missing and results in a syntax error.