### PR TITLE
Добавлено baseline для align-items

### DIFF
--- a/src/core/components/typography/typography.less
+++ b/src/core/components/typography/typography.less
@@ -26,7 +26,7 @@
 .rules-loop(@alignContent, align-content);
 
 // Align Items
-@alignItems: flex-start, flex-end, center, stretch;
+@alignItems: baseline, flex-start, flex-end, center, stretch;
 .rules-loop(@alignItems, align-items);
 
 // Align Self


### PR DESCRIPTION
Не хватало 5го значения: https://css-tricks.com/almanac/properties/a/align-items/