### PR TITLE
Update autocomplete-class.js

### DIFF
--- a/src/core/components/autocomplete/autocomplete-class.js
+++ b/src/core/components/autocomplete/autocomplete-class.js
@@ -39,7 +39,8 @@ class Autocomplete extends Framework7Class {
     if (ac.params.view) {
       view = ac.params.view;
     } else if ($openerEl || $inputEl) {
-      view = app.views.get($openerEl || $inputEl);
+      const $el = $openerEl || $inputEl;
+      view = $el.parents('.view').length && $el.parents('.view')[0].f7View;
     }
     if (!view) view = app.views.main;
 


### PR DESCRIPTION
`$openerEl || $inputEl` is not view DOM node
