### PR TITLE
device.os при запуске веб-страницы с десктопа

### DIFF
--- a/src/core/utils/device.js
+++ b/src/core/utils/device.js
@@ -113,6 +113,12 @@ const Device = (function Device() {
     device.electron = electron;
     device.macos = macos;
     device.windows = windows;
+    if (device.macos) {
+      device.os = 'macos';
+    }
+    if (device.windows) {
+      device.os = 'windows';
+    }
   }
 
   // Meta statusbar


### PR DESCRIPTION
Если мы запускаем F7 как веб-страницу на десктопе, то предлагаю добавить определение device.os, иначе оно будет undefined.

