### PR TITLE
v5: Phenome: add missing sortableTapHold

### DIFF
--- a/src/phenome/components/list-group.jsx
+++ b/src/phenome/components/list-group.jsx
@@ -25,6 +25,7 @@ export default {
       style,
       mediaList,
       sortable,
+      sortableTapHold,
       sortableMoveElements,
     } = props;
 


### PR DESCRIPTION
f7-vue's F7ListGroup is broken, this should fix it