### PR TITLE
Allow datatables to be used in virtual lists.

### DIFF
--- a/src/core/components/virtual-list/virtual-list-class.js
+++ b/src/core/components/virtual-list/virtual-list-class.js
@@ -91,7 +91,7 @@ class VirtualList extends Framework7Class {
 
     // Append <ul>
     const ul = vl.params.ul;
-    vl.$ul = ul ? $(vl.params.ul) : vl.$el.children('ul');
+    vl.$ul = ul ? $(vl.params.ul) : vl.$el.children(ul);
     if (vl.$ul.length === 0 && vl.params.createUl) {
       vl.$el.append('<ul></ul>');
       vl.$ul = vl.$el.children('ul');

--- a/src/core/components/virtual-list/virtual-list-class.js
+++ b/src/core/components/virtual-list/virtual-list-class.js
@@ -91,7 +91,7 @@ class VirtualList extends Framework7Class {
 
     // Append <ul>
     const ul = vl.params.ul;
-    vl.$ul = ul ? $(vl.params.ul) : vl.$el.children(ul);
+    vl.$ul = ul ? $(vl.params.ul) : vl.$el.children('ul');
     if (vl.$ul.length === 0 && vl.params.createUl) {
       vl.$el.append('<ul></ul>');
       vl.$ul = vl.$el.children('ul');
@@ -109,7 +109,7 @@ class VirtualList extends Framework7Class {
       domCache: {},
       displayDomCache: {},
       // Temporary DOM Element
-      tempDomElement: document.createElement('ul'),
+      tempDomElement: document.createElement(ul),
       // Last repain position
       lastRepaintY: null,
       // Fragment


### PR DESCRIPTION
Set tempDomElement to vl.params.ul instead of hardcoding it to 'ul'

This allows the ul to be set to 'tbody'
which enables the use <tr> elements of datatables in virtual-list

eg
let vList = app.virtualList.create({

        el: ".tbody-class",
        ul: 'tbody',
        createUl: true,
        items: someJsonData,
        itemTemplate: function (item) {
          var tmpl = `<tr><td>{{val1}}</td><td>{{val2}}</td></tr>`;
          return Template7.compile(tmpl)(item);
        },
        height: 108,

})
