### PR TITLE
Style month input field to be consistent with other date fields

### DIFF
--- a/src/core/components/input/input.less
+++ b/src/core/components/input/input.less
@@ -8,6 +8,7 @@ input[type="email"],
 input[type="tel"],
 input[type="url"],
 input[type="date"],
+input[type='month'],
 input[type="datetime-local"],
 input[type="time"],
 input[type="number"],
@@ -45,6 +46,7 @@ textarea {
   input[type="tel"],
   input[type="url"],
   input[type="date"],
+  input[type='month'],
   input[type="datetime-local"],
   input[type="time"],
   input[type="number"],
@@ -84,11 +86,13 @@ textarea {
   }
   input[type="time"],
   input[type="date"],
+  input[type='month'],
   input[type="datetime-local"] {
     line-height: var(--f7-input-height);
   }
   .rtl({
     input[type="date"],
+    input[type='month'],
     input[type="datetime-local"] {
       text-align: right;
       flex-direction: row-reverse;


### PR DESCRIPTION
This patch applies the same styling the other date, time etc input fields have to the **month** field so everything looks uniform
