### PR TITLE
Navbar: fix: no-shadow, no-hairline

### DIFF
--- a/src/phenome/components/navbar.jsx
+++ b/src/phenome/components/navbar.jsx
@@ -98,6 +98,8 @@ export default {
         'navbar-large': large,
         'navbar-large-transparent': largeTransparent,
         'navbar-large-collapsed': large && largeCollapsed,
+        'no-shadow': noShadow,
+        'no-hairline': noHairline,
       },
       Mixins.colorClasses(props),
     );
@@ -145,9 +147,7 @@ export default {
           innerClass,
           innerClassName,
           {
-            sliding,
-            'no-shadow': noShadow,
-            'no-hairline': noHairline,
+            sliding, 
             'navbar-inner-left-title': addLeftTitleClass,
             'navbar-inner-centered-title': addCenterTitleClass,
           }


### PR DESCRIPTION
This PR fixes navbar classes: `no-shadow` and `no-hairline`