### PR TITLE
fix for #3448 - removePage in components-rotuter.js causes crash when…

### DIFF
--- a/packages/react/utils/components-router.js
+++ b/packages/react/utils/components-router.js
@@ -59,7 +59,7 @@ export default {
       viewRouter.setPages(viewRouter.pages);
     },
     removePage($pageEl) {
-      if (!$pageEl) return;
+      if (!$pageEl || $pageEl.length === 0) return;
       const router = this;
       let f7Page;
       if ('length' in $pageEl) f7Page = $pageEl[0].f7Page;


### PR DESCRIPTION
… $pageEl length is zero

A check to fix:
Uncaught TypeError: Cannot read property 'f7Page' of undefined