### PR TITLE
make the error explicit when a wrong selector is used to create a view

### DIFF
--- a/src/core/components/view/view-class.js
+++ b/src/core/components/view/view-class.js
@@ -17,10 +17,10 @@ class View extends Framework7Class {
     };
 
     if ($el.length === 0) {
-      let message = `Framework7: can't create a View instance because `;
-      message += (typeof el === 'string') ? 
-        `the selector "${el}" didn't match any element` :
-        `el must be an HTMLElement or Dom7 object`;
+      let message = 'Framework7: can\'t create a View instance because ';
+      message += (typeof el === 'string')
+        ? `the selector "${el}" didn't match any element`
+        : 'el must be an HTMLElement or Dom7 object';
 
       throw new Error(message);
     }

--- a/src/core/components/view/view-class.js
+++ b/src/core/components/view/view-class.js
@@ -16,6 +16,10 @@ class View extends Framework7Class {
       routesAdd: [],
     };
 
+    if ($el.length === 0 && typeof el === 'string') {
+      throw new Error(`Framework7: can't create a View instance because the selector "${el}" didn't match any element`);
+    }
+
     // Default View params
     view.params = Utils.extend(defaults, app.params.view, viewParams);
 

--- a/src/core/components/view/view-class.js
+++ b/src/core/components/view/view-class.js
@@ -16,8 +16,13 @@ class View extends Framework7Class {
       routesAdd: [],
     };
 
-    if ($el.length === 0 && typeof el === 'string') {
-      throw new Error(`Framework7: can't create a View instance because the selector "${el}" didn't match any element`);
+    if ($el.length === 0) {
+      let message = `Framework7: can't create a View instance because `;
+      message += (typeof el === 'string') ? 
+        `the selector "${el}" didn't match any element` :
+        `el must be an HTMLElement or Dom7 object`;
+
+      throw new Error(message);
     }
 
     // Default View params


### PR DESCRIPTION
This is a simple change that gives a better error message for the case when the user tries to create a view like so:

```js
let myView = app.views.create('.somethin');
```

and there is no element matched by `.somethin` (usually this is a simple typo).

Currently F7 gives a cryptic error with this message:

```
Uncaught TypeError: Cannot set property 'f7View' of undefined
```

(which is clear for anyone who knows the internals of F7, but not at all for users who are new to it)
