### PR TITLE
Fixing emit typo which prevented the back button on master-detail fro…

### DIFF
--- a/src/core/modules/router/back.js
+++ b/src/core/modules/router/back.js
@@ -242,7 +242,7 @@ function backward(el, backwardOptions) {
       router.emit('pageMasterUnstack', $newPage[0]);
       if (dynamicNavbar) {
         $(app.navbar.getElByPage($newPage)).removeClass('navbar-master-stacked');
-        router.emi('navbarMasterUnstack', app.navbar.getElByPage($newPage));
+        router.emit('navbarMasterUnstack', app.navbar.getElByPage($newPage));
       }
     }
     // Page init and before init events


### PR DESCRIPTION
* Framework7 version: master
* Platform and Target: All platforms

### Describe the bug
There is a typo on line https://github.com/framework7io/framework7/blob/master/src/core/modules/router/back.js#L245. This should be `emit`.

### To Reproduce
I noticed when using the master detail stack. 
1. Create a master/master-detail view.
2. Inside master-detail add a link to another detail page and click it
3. On the new detail page click the back button

### Expected behavior
The page should navigate back to the previous page in it's history

### Actual Behavior
```
back.js:258 Uncaught TypeError: router.emi is not a function
    at Router.backward (back.js:258)
```
