### PR TITLE
add css variable for the additional page transitions (parallax)

### DIFF
--- a/src/core/components/page/page-transitions/parallax.less
+++ b/src/core/components/page/page-transitions/parallax.less
@@ -1,18 +1,18 @@
 // f7-parallax
 .router-transition-f7-parallax-forward {
   .page-next {
-    animation: f7-parallax-next-to-current 500ms forwards;
+    animation: f7-parallax-next-to-current var(--f7-page-parallax-transition-duration) forwards;
   }
   .page-current {
-    animation: f7-parallax-current-to-prev 500ms forwards;
+    animation: f7-parallax-current-to-prev var(--f7-page-parallax-transition-duration) forwards;
   }
 }
 .router-transition-f7-parallax-backward {
   .page-current {
-    animation: f7-parallax-current-to-next 500ms forwards;
+    animation: f7-parallax-current-to-next var(--f7-page-parallax-transition-duration) forwards;
   }
   .page-previous {
-    animation: f7-parallax-prev-to-current 500ms forwards;
+    animation: f7-parallax-prev-to-current var(--f7-page-parallax-transition-duration) forwards;
   }
 }
 @keyframes f7-parallax-next-to-current {

--- a/src/core/components/page/page-vars.less
+++ b/src/core/components/page/page-vars.less
@@ -3,6 +3,7 @@
   --f7-page-master-border-color: rgba(0,0,0,0.1);
   --f7-page-master-border-width: 1px;
   --f7-page-swipeback-transition-duration: 300ms;
+  --f7-page-parallax-transition-duration: 500ms;
   /*
   --f7-page-content-extra-padding-top: 0px;
   --f7-page-content-extra-padding-bottom: 0px;


### PR DESCRIPTION
`transition-duration` can be set by the user for the default transition (using `--f7-page-transition-duration`), but for the additional transitions (cover, parallax, etc) this is hard-coded.

This PR is done only for parallax because I want to know if there is interest in adding these new variables. If so, I'll update the PR for the remaining effects.