### PR TITLE
Update modal-class.js

### DIFF
--- a/src/core/components/modal/modal-class.js
+++ b/src/core/components/modal/modal-class.js
@@ -233,6 +233,9 @@ class Modal extends Framework7Class {
   destroy() {
     const modal = this;
     if (modal.destroyed) return;
+    if (modal.$el && modal.$el.hasClass('modal-out')) {
+      modal.onClosed();
+    }
     modal.emit(`local::beforeDestroy modalBeforeDestroy ${modal.type}BeforeDestroy`, modal);
     if (modal.$el) {
       modal.$el.trigger(`modal:beforedestroy ${modal.type.toLowerCase()}:beforedestroy`);


### PR DESCRIPTION
In some scenarios, the modal.close() is invoked, but modal.destroy() will be invoked before the animationEnd/transitionEnd, so the modal.onClosed() will not be invoked forever