### PR TITLE
Default size for img used as notification's icon

### DIFF
--- a/src/core/components/notification/notification.less
+++ b/src/core/components/notification/notification.less
@@ -65,6 +65,9 @@
   i {
     font-size: var(--f7-notification-icon-size);
   }
+  img {
+    height: var(--f7-notification-icon-size);
+  }
 }
 .notification-header {
   display: flex;


### PR DESCRIPTION
When using an img as an icon for notification (something officially supported since it's described in the doc), the size of the image is not adapted. It's easy to correct, but it would be even more easier to have it working out of the box. 