### PR TITLE
Popup overlap adapted to iOS 13

### DIFF
--- a/src/core/components/popup/popup-class.js
+++ b/src/core/components/popup/popup-class.js
@@ -258,8 +258,11 @@ class Popup extends Modal {
         );
       }
       if (isPush) {
-        pushOffset = parseInt($el.css('--f7-popup-push-offset'), 10);
-        if (Number.isNaN(pushOffset)) pushOffset = 0;
+        let offset = parseInt($el.css('--f7-popup-push-offset'), 10);
+        let overlap = parseInt($el.css('--f7-popup-push-overlap'), 10);
+        if (Number.isNaN(offset)) offset = 0;
+        if (Number.isNaN(overlap)) overlap = 0;
+        pushOffset = offset + overlap;
         if (pushOffset) {
           $el.addClass('popup-push');
           popup.$htmlEl.addClass('with-modal-popup-push');

--- a/src/core/components/popup/popup-vars.less
+++ b/src/core/components/popup/popup-vars.less
@@ -4,6 +4,7 @@
   --f7-popup-tablet-height: 630px;
   --f7-popup-transition-duration: 400ms;
   --f7-popup-push-border-radius: 10px;
+  --f7-popup-push-overlap: 10px;
   --f7-popup-push-offset: var(--f7-safe-area-top);
   /*
   --f7-popup-tablet-border-radius: var(--f7-popup-border-radius);

--- a/src/core/components/popup/popup.less
+++ b/src/core/components/popup/popup.less
@@ -73,8 +73,8 @@ html.with-modal-popup {
 html.with-modal-popup-push,
 html.with-modal-popup-push-closing {
   .popup-push {
-    top: calc(var(--f7-popup-push-offset) + 10px);
-    height: calc(100% - var(--f7-popup-push-offset) - 10px);
+    top: calc(var(--f7-popup-push-offset) + 20px);
+    height: calc(100% - var(--f7-popup-push-offset) - 20px);
     border-radius: var(--f7-popup-push-border-radius) var(--f7-popup-push-border-radius) 0 0;
     .view, .page {
       --f7-safe-area-top: 0px;

--- a/src/core/less/mixins.less
+++ b/src/core/less/mixins.less
@@ -86,11 +86,11 @@
   top: 0;
   width: 100%;
   height: 100%;
-  background: rgba(0,0,0,0.4);
+  background: rgba(0,0,0,0.09677419);
   z-index: 13000;
   visibility: hidden;
   opacity: 0;
-  transition-duration: 400ms;
+  transition-duration: 400ms; 
   &.not-animated {
     transition-duration: 0ms;
   }


### PR DESCRIPTION
This change corrects the distance of overlap of the push view. The reference here is a push view from the iOS app store. You can see that the distance is much larger in iOS than in Framework7. Also, the backdrop shaddow is a bit more transparent in iOS.

Here is the screenshot from the iOS App Store:
![image](https://user-images.githubusercontent.com/11940390/76548730-80123800-648f-11ea-9994-1fc18cc012e3.png)

Screenshot before the change:
![image](https://user-images.githubusercontent.com/11940390/76548755-899ba000-648f-11ea-8ca4-b13068a98b06.png)

Screenshot after the change:
![image](https://user-images.githubusercontent.com/11940390/76548775-8ef8ea80-648f-11ea-8f05-2efc7a6daa1a.png)

