### PR TITLE
Copy children with slot prop other than `default` to `default`

### DIFF
--- a/src/phenome/components/link.jsx
+++ b/src/phenome/components/link.jsx
@@ -73,7 +73,11 @@ export default {
       style,
     } = props;
 
-    const defaultSlots = self.slots.default;
+    const defaultSlots = self.slots.default || [];
+    Object.keys(self.slots).forEach(key => {
+      if (typeof self.slots[key] === 'undefined' || key === 'default') return;
+      self.slots[key].forEach(child => defaultSlots.push(child));
+    });
 
     let iconEl;
     let textEl;


### PR DESCRIPTION
This change is proposed to resolve Issue #3577