### PR TITLE
text-editor-popover position relative to f7-root

### DIFF
--- a/src/core/components/text-editor/text-editor-class.js
+++ b/src/core/components/text-editor/text-editor-class.js
@@ -238,7 +238,8 @@ class TextEditor extends Framework7Class {
       if (!selection.isCollapsed && selection.rangeCount) {
         const range = selection.getRangeAt(0);
         const rect = range.getBoundingClientRect();
-        self.openPopover(rect.x + (window.scrollX || 0), rect.y + (window.scrollY || 0), rect.width, rect.height);
+        const f7root = document.getElementById('framework7-root');
+        self.openPopover(rect.x + (window.scrollX || 0) - f7root.offsetLeft, rect.y + (window.scrollY || 0) - f7root.offsetTop, rect.width, rect.height);
       } else if (selection.isCollapsed) {
         self.closePopover();
       }

--- a/src/core/components/text-editor/text-editor-class.js
+++ b/src/core/components/text-editor/text-editor-class.js
@@ -238,8 +238,8 @@ class TextEditor extends Framework7Class {
       if (!selection.isCollapsed && selection.rangeCount) {
         const range = selection.getRangeAt(0);
         const rect = range.getBoundingClientRect();
-        const f7root = document.getElementById('framework7-root');
-        self.openPopover(rect.x + (window.scrollX || 0) - f7root.offsetLeft, rect.y + (window.scrollY || 0) - f7root.offsetTop, rect.width, rect.height);
+        const rootEl = self.app.root[0] || document.body;
+        self.openPopover(rect.x + (window.scrollX || 0) - rootEl.offsetLeft, rect.y + (window.scrollY || 0) - rootEl.offsetTop, rect.width, rect.height);
       } else if (selection.isCollapsed) {
         self.closePopover();
       }


### PR DESCRIPTION
As described here: https://github.com/framework7io/framework7/issues/3617
The popover is relative (css'ly speaking) to the #framework7-root element, but is computed relative to the html element.
The proposal is to compute the position relative to the #framework7-root element

**Important: I haven't been able to test if for real! It should work, but it should definitely not be merged without real verification!**