### PR TITLE
Panel transition when pushing popup opens

### DIFF
--- a/src/core/components/panel/panel.less
+++ b/src/core/components/panel/panel.less
@@ -186,6 +186,30 @@ html {
     transform: translate3d(0px,0,0);
   }
 }
+
+html.with-modal-popup-push .framework7-root > .panel {
+  &.panel-in,
+  &.panel-out {
+    transition-duration: var(--f7-popup-transition-duration);
+
+    &.panel-reveal.panel-left {
+      transform: translate3d(calc((1 - var(--f7-popup-push-scale, 1)) * 50vw), 0, 0px) scale(var(--f7-popup-push-scale, 1));
+    }
+    &.panel-reveal.panel-right {
+      transform: translate3d(calc((1 - var(--f7-popup-push-scale, 1)) * -50vw), 0, 0px) scale(var(--f7-popup-push-scale, 1));
+    }
+    &.panel-cover.panel-left {
+      transform: translate3d(-100%, 0, 0px);
+    }
+    &.panel-cover.panel-right {
+      transform: translate3d(100%, 0, 0px);
+    }
+  }
+}
+html.with-modal-popup-push-closing .framework7-root > .panel.panel-in {
+  transition-duration: var(--f7-popup-transition-duration);
+}
+
 .panel-resize-handler {
   position: absolute;
   top: 0;


### PR DESCRIPTION
My app is using colors for headers, and I observed that panels do not behave beautifully when a link inside the panel is opening a "pushing" popup _(it's also the case with default colors, but it's less obvious, at least with the dark theme on revealed panels, since the header of the panel is almost black)_

The PR implements some transitions that make the app beautiful again.

It takes care of right and left panels, different effects for cover and reveal panel (respectively "go away" and "go below" effect), and works well when the panel is closed at the same time that it opens the popup. 

Few things to notice:

- I changed the transition duration so it matches the one of the popup: so when the popup is closing, the panels and the pushed view are back to their respective place at the same time
- It does not take care of "progressively going back" when the user is swiping to close: it would imply to also change the "pushed view" behavior so it moves horizontally and not only vertically. But it is definitely not a requirement ; as is, it's already very good looking.
- The `translate3d(calc((1 - var(--f7-popup-push-scale, 1)) * 50vw), 0, 0px)` is required because the scale alone keeps the panel visible _(since the panel is less wide than the view, scaling it down of the same amount make it "translate" less)_. 
The formula ensures that the panel is translated left as much as the visible "margin" between the pushed view and the viewport created by the scaling of the view _(I consider here that "pusing popup" are pushing only on screens where `f7-root.width === viewport.width`)._ And then, since the panel is scaled down too, it's even more "away" from the edge of the viewport.
An alternative is to change the origin of the scale (see next comment)
- I initially added border radius for the "reveal" panels _(must be done two times, on the panel itself and on the view inside)_, but it is not necessary: with the "double" translation (see previous point), the corners are not visible anyway _(unless your panel is extremely skinny, or your radius extremely big)_

You can test everything on this fiddle: 
https://jsfiddle.net/eazLq8ku/3/