### PR TITLE
Fix return type of app.virtualList.get

### DIFF
--- a/src/core/components/virtual-list/virtual-list.d.ts
+++ b/src/core/components/virtual-list/virtual-list.d.ts
@@ -122,7 +122,7 @@ export namespace VirtualList {
       /** destroy Virtual List instance */
       destroy(el: HTMLElement | CSSSelector): void
       /** get Virtual List instance by HTML element */
-      get(el: HTMLElement | CSSSelector): void
+      get(el: HTMLElement | CSSSelector): VirtualList
     }
   }
   interface AppParams {


### PR DESCRIPTION
* Framework7 version: 5.7.7
* Platform and Target: All

### Describe the bug
`app.virtualList.get ` TypeScript definition returns type void instead of VirtualList in virtual-list.d.ts https://github.com/framework7io/framework7/blob/37ac11bd26cacd7f3b6781d83c9f48daa8cc3b19/src/core/components/virtual-list/virtual-list.d.ts#L125

### To Reproduce
Try to get a virtualList instance in TypeScript.

### Expected behavior
Return a virtualList instance.

### Actual Behavior
Returns void