### PR TITLE
Изменение приоритета в сообщении о валидации

### DIFF
--- a/src/core/components/input/input.js
+++ b/src/core/components/input/input.js
@@ -74,7 +74,7 @@ const Input = {
     }
     unsetReadonly();
     const validity = $inputEl[0].validity;
-    const validationMessage = $inputEl.dataset().errorMessage || $inputEl[0].validationMessage || '';
+    const validationMessage = $inputEl[0].validationMessage || $inputEl.dataset().errorMessage || '';
     if (!validity) {
       setReadonly();
       return true;


### PR DESCRIPTION
На мой взгляд, сперва должно идти сообщение, установленное setCustomValidity, а уже затем что в data-error-message="..."

У нас есть поле, JS должен проверить заполненность поля, ну чтобы не отправлять заранее пустое:

```<input name="..." type="text" required validate data-error-message="Заполните поле.">```

Сервер уже валидирует полноценно, например, на наличие цифр. Поэтому я вызываю setCustomValidity() с конкретным описанием ошибки. В текущем виде оно не будет отображено, так как имеет меньший приоритет, чем data-error-message. Данным реквестом я предлагаю исправить это.