### PR TITLE
Fixed issue template name field

### DIFF
--- a/.github/ISSUE_TEMPLATE/framewor7-react-issue.md
+++ b/.github/ISSUE_TEMPLATE/framewor7-react-issue.md
@@ -1,5 +1,5 @@
 ---
-name: Framewor7-React Issue
+name: Framework7-React Issue
 about: Create a report to help us improve
 
 ---

--- a/.github/ISSUE_TEMPLATE/framewor7-svelte-issue.md
+++ b/.github/ISSUE_TEMPLATE/framewor7-svelte-issue.md
@@ -1,5 +1,5 @@
 ---
-name: Framewor7-Svelte Issue
+name: Framework7-Svelte Issue
 about: Create a report to help us improve
 
 ---

--- a/.github/ISSUE_TEMPLATE/framewor7-vue-issue.md
+++ b/.github/ISSUE_TEMPLATE/framewor7-vue-issue.md
@@ -1,5 +1,5 @@
 ---
-name: Framewor7-Vue Issue
+name: Framework7-Vue Issue
 about: Create a report to help us improve
 
 ---


### PR DESCRIPTION
Fixed issue template name field _Framewor7_ -> **Framework7** for React, Svelte and Vue (The one in the Core version was fixed already six months ago).

I would like to point out that the same typo is also present in the name of these four files:

![file-names](https://user-images.githubusercontent.com/1197819/92321635-b938f880-f02b-11ea-932b-56a2355a04fe.png)
