### PR TITLE
Correct text of the "Password" dialog example

### DIFF
--- a/kitchen-sink/core/pages/dialog.html
+++ b/kitchen-sink/core/pages/dialog.html
@@ -84,7 +84,7 @@
       },
       openPassword: function () {
         var app = this.$app;
-        app.dialog.password('Enter your username and password', function (password) {
+        app.dialog.password('Enter your password', function (password) {
           app.dialog.alert('Thank you!<br>Password:' + password);
         });
       },

--- a/kitchen-sink/core/pages/list.html
+++ b/kitchen-sink/core/pages/list.html
@@ -445,7 +445,7 @@
 
     <div class="block-title">Media Lists</div>
     <div class="block">
-      <p>Media Lists are almost the same as Data Lists, but with a more flexible layout for visualization of more complex data, like products, services, userc, etc.</p>
+      <p>Media Lists are almost the same as Data Lists, but with a more flexible layout for visualization of more complex data, like products, services, users, etc.</p>
     </div>
     <div class="block-title">Songs</div>
     <div class="list media-list">

--- a/kitchen-sink/react/src/pages/dialog.jsx
+++ b/kitchen-sink/react/src/pages/dialog.jsx
@@ -77,7 +77,7 @@ export default class extends React.Component {
   }
   openPassword() {
     const app = this.$f7;
-    app.dialog.password('Enter your username and password', (password) => {
+    app.dialog.password('Enter your password', (password) => {
       app.dialog.alert(`Thank you!<br>Password:${password}`);
     });
   }

--- a/kitchen-sink/react/src/pages/list.jsx
+++ b/kitchen-sink/react/src/pages/list.jsx
@@ -163,7 +163,7 @@ export default () => (
 
     <BlockTitle>Media Lists</BlockTitle>
     <Block>
-      <p>Media Lists are almost the same as Data Lists, but with a more flexible layout for visualization of more complex data, like products, services, userc, etc.</p>
+      <p>Media Lists are almost the same as Data Lists, but with a more flexible layout for visualization of more complex data, like products, services, users, etc.</p>
     </Block>
     <BlockTitle>Songs</BlockTitle>
     <List mediaList>

--- a/kitchen-sink/svelte/src/pages/dialog.svelte
+++ b/kitchen-sink/svelte/src/pages/dialog.svelte
@@ -64,7 +64,7 @@
     });
   }
   function openPassword() {
-    f7.dialog.password('Enter your username and password', (password) => {
+    f7.dialog.password('Enter your password', (password) => {
       f7.dialog.alert(`Thank you!<br>Password:${password}`);
     });
   }

--- a/kitchen-sink/svelte/src/pages/list.svelte
+++ b/kitchen-sink/svelte/src/pages/list.svelte
@@ -167,7 +167,7 @@
 
   <BlockTitle>Media Lists</BlockTitle>
   <Block>
-    <p>Media Lists are almost the same as Data Lists, but with a more flexible layout for visualization of more complex data, like products, services, userc, etc.</p>
+    <p>Media Lists are almost the same as Data Lists, but with a more flexible layout for visualization of more complex data, like products, services, users, etc.</p>
   </Block>
   <BlockTitle>Songs</BlockTitle>
   <List mediaList>

--- a/kitchen-sink/vue/src/pages/dialog.vue
+++ b/kitchen-sink/vue/src/pages/dialog.vue
@@ -81,7 +81,7 @@
       },
       openPassword() {
         const app = this.$f7;
-        app.dialog.password('Enter your username and password', (password) => {
+        app.dialog.password('Enter your password', (password) => {
           app.dialog.alert(`Thank you!<br>Password:${password}`);
         });
       },

--- a/kitchen-sink/vue/src/pages/list.vue
+++ b/kitchen-sink/vue/src/pages/list.vue
@@ -160,7 +160,7 @@
 
     <f7-block-title>Media Lists</f7-block-title>
     <f7-block>
-      <p>Media Lists are almost the same as Data Lists, but with a more flexible layout for visualization of more complex data, like products, services, userc, etc.</p>
+      <p>Media Lists are almost the same as Data Lists, but with a more flexible layout for visualization of more complex data, like products, services, users, etc.</p>
     </f7-block>
     <f7-block-title>Songs</f7-block-title>
     <f7-list media-list>


### PR DESCRIPTION
for Kitchen Sink Core / React / Svelte / Vue

A typo on "list" pages is also fixed.