### PR TITLE
Typo in svelte "LoginScreen" event handlers names

### DIFF
--- a/src/svelte/components/login-screen.svelte
+++ b/src/svelte/components/login-screen.svelte
@@ -36,19 +36,19 @@
 
   function onOpen(instance) {
     dispatch('loginscreenOpen', [instance]);
-    if (typeof $$props.onLoginscreenOpen === 'function') $$props.onLoginscreenOpen(instance);
+    if (typeof $$props.onLoginScreenOpen === 'function') $$props.onLoginScreenOpen(instance);
   }
   function onOpened(instance) {
     dispatch('loginscreenOpened', [instance]);
-    if (typeof $$props.onLoginscreenOpened === 'function') $$props.onLoginscreenOpened(instance);
+    if (typeof $$props.onLoginScreenOpened === 'function') $$props.onLoginScreenOpened(instance);
   }
   function onClose(instance) {
     dispatch('loginscreenClose', [instance]);
-    if (typeof $$props.onLoginscreenClose === 'function') $$props.onLoginscreenClose(instance);
+    if (typeof $$props.onLoginScreenClose === 'function') $$props.onLoginScreenClose(instance);
   }
   function onClosed(instance) {
     dispatch('loginscreenClosed', [instance]);
-    if (typeof $$props.onLoginscreenClosed === 'function') $$props.onLoginscreenClosed(instance);
+    if (typeof $$props.onLoginScreenClosed === 'function') $$props.onLoginScreenClosed(instance);
   }
 
   let initialWatched = false;


### PR DESCRIPTION
As [Docs reports](https://framework7.io/svelte/login-screen.html#login-screen-events) the event name must start with "onLoginScreen..." and not "onLoginscreen...".
Is not a case that the example in docs is buggy and does not fires the events.
