### PR TITLE
Fixed typo in stepper pages and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1709,7 +1709,7 @@
     * Input
       * Fixed wrong resizable textarea calculation in Firefox
     * Stepper
-      * Has new "manual input mode". When enabled it allows to type value from keyboar and check fractional part with defined accurancy. Also, when enabled, then `step` parameter is ignored during typing. It has 3 new parameters:
+      * Has new "manual input mode". When enabled it allows to type value from keyboard and check fractional part with defined accurancy. Also, when enabled, then `step` parameter is ignored during typing. It has 3 new parameters:
         * `manualInputMode: false` - enables manual input mode
         * `decimalPoint: 4` - number of digits after dot
         * `buttonsEndInputMode: true` - disables manual input mode on Stepper's button click

--- a/kitchen-sink/core/pages/data-table.html
+++ b/kitchen-sink/core/pages/data-table.html
@@ -18,7 +18,7 @@
         <table>
           <thead>
             <tr>
-              <th class="label-cell">Desert (100g serving)</th>
+              <th class="label-cell">Dessert (100g serving)</th>
               <th class="numeric-cell">Calories</th>
               <th class="numeric-cell">Fat (g)</th>
               <th class="numeric-cell">Carbs</th>
@@ -62,7 +62,7 @@
         <table>
           <thead>
             <tr>
-              <th class="label-cell">Desert (100g serving)</th>
+              <th class="label-cell">Dessert (100g serving)</th>
               <th class="numeric-cell">Calories</th>
               <th class="numeric-cell">Fat (g)</th>
               <th class="numeric-cell">Carbs</th>
@@ -106,7 +106,7 @@
         <table>
           <thead>
             <tr>
-              <th class="label-cell">Desert (100g serving)</th>
+              <th class="label-cell">Dessert (100g serving)</th>
               <th class="numeric-cell">Calories</th>
               <th class="numeric-cell">Fat (g)</th>
               <th class="numeric-cell">Carbs</th>
@@ -178,7 +178,7 @@
                   <i class="icon-checkbox"></i>
                 </label>
               </th>
-              <th class="label-cell">Desert (100g serving)</th>
+              <th class="label-cell">Dessert (100g serving)</th>
               <th class="numeric-cell">Calories</th>
               <th class="numeric-cell">Fat (g)</th>
               <th class="numeric-cell">Carbs</th>
@@ -286,7 +286,7 @@
                   <i class="icon-checkbox"></i>
                 </label>
               </th>
-              <th class="label-cell">Desert (100g serving)</th>
+              <th class="label-cell">Dessert (100g serving)</th>
               <th class="numeric-cell">Calories</th>
               <th class="numeric-cell">Fat (g)</th>
               <th class="numeric-cell">Carbs</th>
@@ -434,7 +434,7 @@
                     <i class="icon-checkbox"></i>
                   </label>
                 </th>
-                <th class="label-cell">Desert (100g serving)</th>
+                <th class="label-cell">Dessert (100g serving)</th>
                 <th class="numeric-cell">Calories</th>
                 <th class="numeric-cell">Fat (g)</th>
                 <th class="numeric-cell">Carbs</th>
@@ -519,7 +519,7 @@
                     <i class="icon-checkbox"></i>
                   </label>
                 </th>
-                <th class="label-cell sortable-cell sortable-cell-active">Desert (100g serving)</th>
+                <th class="label-cell sortable-cell sortable-cell-active">Dessert (100g serving)</th>
                 <th class="numeric-cell sortable-cell">Calories</th>
                 <th class="numeric-cell sortable-cell">Fat (g)</th>
                 <th class="numeric-cell sortable-cell">Carbs</th>
@@ -610,7 +610,7 @@
                     <i class="icon-checkbox"></i>
                   </label>
                 </th>
-                <th class="label-cell">Desert (100g serving)</th>
+                <th class="label-cell">Dessert (100g serving)</th>
                 <th class="numeric-cell">Calories</th>
                 <th class="numeric-cell">Fat (g)</th>
                 <th class="numeric-cell">Carbs</th>
@@ -695,7 +695,7 @@
                     <i class="icon-checkbox"></i>
                   </label>
                 </th>
-                <th class="label-cell">Desert (100g serving)</th>
+                <th class="label-cell">Dessert (100g serving)</th>
                 <th class="numeric-cell">Calories</th>
                 <th class="numeric-cell">Fat (g)</th>
                 <th class="numeric-cell">Carbs</th>
@@ -782,7 +782,7 @@
           <table>
             <thead>
               <tr>
-                <th class="label-cell">Desert (100g serving)</th>
+                <th class="label-cell">Dessert (100g serving)</th>
                 <th class="numeric-cell">Calories</th>
                 <th class="numeric-cell">Fat (g)</th>
                 <th class="numeric-cell">Carbs</th>

--- a/kitchen-sink/core/pages/stepper.html
+++ b/kitchen-sink/core/pages/stepper.html
@@ -508,7 +508,7 @@
         </ul>
       </div>
       <div class="block-title">Manual input</div>
-      <div class="block-header">It is possible to enter value manually from keyboard or mobile keypad. When click on input field, stepper enter into manual input mode, which allow type value from keyboar and check fractional part with defined accurancy. Click outside or enter Return key, ending manual mode.</div>
+      <div class="block-header">It is possible to enter value manually from keyboard or mobile keypad. When click on input field, stepper enter into manual input mode, which allow type value from keyboard and check fractional part with defined accurancy. Click outside or enter Return key, ending manual mode.</div>
       <div class="block block-strong text-align-center">
         <div class="row">
           <div class="col">

--- a/kitchen-sink/react/src/pages/data-table.jsx
+++ b/kitchen-sink/react/src/pages/data-table.jsx
@@ -9,7 +9,7 @@ export default () => (
       <table>
         <thead>
           <tr>
-            <th className="label-cell">Desert (100g serving)</th>
+            <th className="label-cell">Dessert (100g serving)</th>
             <th className="numeric-cell">Calories</th>
             <th className="numeric-cell">Fat (g)</th>
             <th className="numeric-cell">Carbs</th>
@@ -53,7 +53,7 @@ export default () => (
       <table>
         <thead>
           <tr>
-            <th className="label-cell">Desert (100g serving)</th>
+            <th className="label-cell">Dessert (100g serving)</th>
             <th className="numeric-cell">Calories</th>
             <th className="numeric-cell">Fat (g)</th>
             <th className="numeric-cell">Carbs</th>
@@ -101,7 +101,7 @@ export default () => (
             <th className="checkbox-cell">
               <Checkbox />
             </th>
-            <th className="label-cell">Desert (100g serving)</th>
+            <th className="label-cell">Dessert (100g serving)</th>
             <th className="numeric-cell">Calories</th>
             <th className="numeric-cell">Fat (g)</th>
             <th className="numeric-cell">Carbs</th>
@@ -179,7 +179,7 @@ export default () => (
             <th className="checkbox-cell">
               <Checkbox />
             </th>
-            <th className="label-cell">Desert (100g serving)</th>
+            <th className="label-cell">Dessert (100g serving)</th>
             <th className="numeric-cell">Calories</th>
             <th className="numeric-cell">Fat (g)</th>
             <th className="numeric-cell">Carbs</th>
@@ -316,7 +316,7 @@ export default () => (
               <th className="checkbox-cell">
                 <Checkbox />
               </th>
-              <th className="label-cell">Desert (100g serving)</th>
+              <th className="label-cell">Dessert (100g serving)</th>
               <th className="numeric-cell">Calories</th>
               <th className="numeric-cell">Fat (g)</th>
               <th className="numeric-cell">Carbs</th>
@@ -390,7 +390,7 @@ export default () => (
               <th className="checkbox-cell">
                 <Checkbox />
               </th>
-              <th className="label-cell sortable-cell sortable-cell-active">Desert (100g serving)</th>
+              <th className="label-cell sortable-cell sortable-cell-active">Dessert (100g serving)</th>
               <th className="numeric-cell sortable-cell">Calories</th>
               <th className="numeric-cell sortable-cell">Fat (g)</th>
               <th className="numeric-cell sortable-cell">Carbs</th>
@@ -472,7 +472,7 @@ export default () => (
               <th className="checkbox-cell">
                 <Checkbox />
               </th>
-              <th className="label-cell">Desert (100g serving)</th>
+              <th className="label-cell">Dessert (100g serving)</th>
               <th className="numeric-cell">Calories</th>
               <th className="numeric-cell">Fat (g)</th>
               <th className="numeric-cell">Carbs</th>
@@ -546,7 +546,7 @@ export default () => (
               <th className="checkbox-cell">
                 <Checkbox />
               </th>
-              <th className="label-cell">Desert (100g serving)</th>
+              <th className="label-cell">Dessert (100g serving)</th>
               <th className="numeric-cell">Calories</th>
               <th className="numeric-cell">Fat (g)</th>
               <th className="numeric-cell">Carbs</th>
@@ -637,7 +637,7 @@ export default () => (
         <table>
           <thead>
             <tr>
-              <th className="label-cell">Desert (100g serving)</th>
+              <th className="label-cell">Dessert (100g serving)</th>
               <th className="numeric-cell">Calories</th>
               <th className="numeric-cell">Fat (g)</th>
               <th className="numeric-cell">Carbs</th>

--- a/kitchen-sink/react/src/pages/stepper.jsx
+++ b/kitchen-sink/react/src/pages/stepper.jsx
@@ -267,7 +267,7 @@ export default class extends React.Component {
         </List>
 
         <BlockTitle>Manual input</BlockTitle>
-        <BlockHeader>It is possible to enter value manually from keyboard or mobile keypad. When click on input field, stepper enter into manual input mode, which allow type value from keyboar and check fractional part with defined accurancy. Click outside or enter Return key, ending manual mode.</BlockHeader>
+        <BlockHeader>It is possible to enter value manually from keyboard or mobile keypad. When click on input field, stepper enter into manual input mode, which allow type value from keyboard and check fractional part with defined accurancy. Click outside or enter Return key, ending manual mode.</BlockHeader>
         <Block strong className="text-align-center">
           <Row>
             <Col>

--- a/kitchen-sink/svelte/src/pages/data-table.svelte
+++ b/kitchen-sink/svelte/src/pages/data-table.svelte
@@ -6,7 +6,7 @@
     <table>
       <thead>
         <tr>
-          <th class="label-cell">Desert (100g serving)</th>
+          <th class="label-cell">Dessert (100g serving)</th>
           <th class="numeric-cell">Calories</th>
           <th class="numeric-cell">Fat (g)</th>
           <th class="numeric-cell">Carbs</th>
@@ -50,7 +50,7 @@
     <table>
       <thead>
         <tr>
-          <th class="label-cell">Desert (100g serving)</th>
+          <th class="label-cell">Dessert (100g serving)</th>
           <th class="numeric-cell">Calories</th>
           <th class="numeric-cell">Fat (g)</th>
           <th class="numeric-cell">Carbs</th>
@@ -98,7 +98,7 @@
           <th class="checkbox-cell">
             <Checkbox />
           </th>
-          <th class="label-cell">Desert (100g serving)</th>
+          <th class="label-cell">Dessert (100g serving)</th>
           <th class="numeric-cell">Calories</th>
           <th class="numeric-cell">Fat (g)</th>
           <th class="numeric-cell">Carbs</th>
@@ -176,7 +176,7 @@
           <th class="checkbox-cell">
             <Checkbox />
           </th>
-          <th class="label-cell">Desert (100g serving)</th>
+          <th class="label-cell">Dessert (100g serving)</th>
           <th class="numeric-cell">Calories</th>
           <th class="numeric-cell">Fat (g)</th>
           <th class="numeric-cell">Carbs</th>
@@ -313,7 +313,7 @@
             <th class="checkbox-cell">
               <Checkbox />
             </th>
-            <th class="label-cell">Desert (100g serving)</th>
+            <th class="label-cell">Dessert (100g serving)</th>
             <th class="numeric-cell">Calories</th>
             <th class="numeric-cell">Fat (g)</th>
             <th class="numeric-cell">Carbs</th>
@@ -387,7 +387,7 @@
             <th class="checkbox-cell">
               <Checkbox />
             </th>
-            <th class="label-cell sortable-cell sortable-cell-active">Desert (100g serving)</th>
+            <th class="label-cell sortable-cell sortable-cell-active">Dessert (100g serving)</th>
             <th class="numeric-cell sortable-cell">Calories</th>
             <th class="numeric-cell sortable-cell">Fat (g)</th>
             <th class="numeric-cell sortable-cell">Carbs</th>
@@ -469,7 +469,7 @@
             <th class="checkbox-cell">
               <Checkbox />
             </th>
-            <th class="label-cell">Desert (100g serving)</th>
+            <th class="label-cell">Dessert (100g serving)</th>
             <th class="numeric-cell">Calories</th>
             <th class="numeric-cell">Fat (g)</th>
             <th class="numeric-cell">Carbs</th>
@@ -546,7 +546,7 @@
             <th class="checkbox-cell">
               <Checkbox />
             </th>
-            <th class="label-cell">Desert (100g serving)</th>
+            <th class="label-cell">Dessert (100g serving)</th>
             <th class="numeric-cell">Calories</th>
             <th class="numeric-cell">Fat (g)</th>
             <th class="numeric-cell">Carbs</th>
@@ -637,7 +637,7 @@
       <table>
         <thead>
           <tr>
-            <th class="label-cell">Desert (100g serving)</th>
+            <th class="label-cell">Dessert (100g serving)</th>
             <th class="numeric-cell">Calories</th>
             <th class="numeric-cell">Fat (g)</th>
             <th class="numeric-cell">Carbs</th>

--- a/kitchen-sink/svelte/src/pages/stepper.svelte
+++ b/kitchen-sink/svelte/src/pages/stepper.svelte
@@ -257,7 +257,7 @@
   </List>
 
   <BlockTitle>Manual input</BlockTitle>
-  <BlockHeader>It is possible to enter value manually from keyboard or mobile keypad. When click on input field, stepper enter into manual input mode, which allow type value from keyboar and check fractional part with defined accurancy. Click outside or enter Return key, ending manual mode.</BlockHeader>
+  <BlockHeader>It is possible to enter value manually from keyboard or mobile keypad. When click on input field, stepper enter into manual input mode, which allow type value from keyboard and check fractional part with defined accurancy. Click outside or enter Return key, ending manual mode.</BlockHeader>
   <Block strong class="text-align-center">
     <Row>
       <Col>

--- a/kitchen-sink/vue/src/pages/data-table.vue
+++ b/kitchen-sink/vue/src/pages/data-table.vue
@@ -6,7 +6,7 @@
       <table>
         <thead>
           <tr>
-            <th class="label-cell">Desert (100g serving)</th>
+            <th class="label-cell">Dessert (100g serving)</th>
             <th class="numeric-cell">Calories</th>
             <th class="numeric-cell">Fat (g)</th>
             <th class="numeric-cell">Carbs</th>
@@ -50,7 +50,7 @@
       <table>
         <thead>
           <tr>
-            <th class="label-cell">Desert (100g serving)</th>
+            <th class="label-cell">Dessert (100g serving)</th>
             <th class="numeric-cell">Calories</th>
             <th class="numeric-cell">Fat (g)</th>
             <th class="numeric-cell">Carbs</th>
@@ -100,7 +100,7 @@
                 <i class="icon-checkbox"></i>
               </label>
             </th>
-            <th class="label-cell">Desert (100g serving)</th>
+            <th class="label-cell">Dessert (100g serving)</th>
             <th class="numeric-cell">Calories</th>
             <th class="numeric-cell">Fat (g)</th>
             <th class="numeric-cell">Carbs</th>
@@ -208,7 +208,7 @@
                 <i class="icon-checkbox"></i>
               </label>
             </th>
-            <th class="label-cell">Desert (100g serving)</th>
+            <th class="label-cell">Dessert (100g serving)</th>
             <th class="numeric-cell">Calories</th>
             <th class="numeric-cell">Fat (g)</th>
             <th class="numeric-cell">Carbs</th>
@@ -359,7 +359,7 @@
                   <i class="icon-checkbox"></i>
                 </label>
               </th>
-              <th class="label-cell">Desert (100g serving)</th>
+              <th class="label-cell">Dessert (100g serving)</th>
               <th class="numeric-cell">Calories</th>
               <th class="numeric-cell">Fat (g)</th>
               <th class="numeric-cell">Carbs</th>
@@ -447,7 +447,7 @@
                   <i class="icon-checkbox"></i>
                 </label>
               </th>
-              <th class="label-cell sortable-cell sortable-cell-active">Desert (100g serving)</th>
+              <th class="label-cell sortable-cell sortable-cell-active">Dessert (100g serving)</th>
               <th class="numeric-cell sortable-cell">Calories</th>
               <th class="numeric-cell sortable-cell">Fat (g)</th>
               <th class="numeric-cell sortable-cell">Carbs</th>
@@ -544,7 +544,7 @@
                   <i class="icon-checkbox"></i>
                 </label>
               </th>
-              <th class="label-cell">Desert (100g serving)</th>
+              <th class="label-cell">Dessert (100g serving)</th>
               <th class="numeric-cell">Calories</th>
               <th class="numeric-cell">Fat (g)</th>
               <th class="numeric-cell">Carbs</th>
@@ -632,7 +632,7 @@
                   <i class="icon-checkbox"></i>
                 </label>
               </th>
-              <th class="label-cell">Desert (100g serving)</th>
+              <th class="label-cell">Dessert (100g serving)</th>
               <th class="numeric-cell">Calories</th>
               <th class="numeric-cell">Fat (g)</th>
               <th class="numeric-cell">Carbs</th>
@@ -734,7 +734,7 @@
         <table>
           <thead>
             <tr>
-              <th class="label-cell">Desert (100g serving)</th>
+              <th class="label-cell">Dessert (100g serving)</th>
               <th class="numeric-cell">Calories</th>
               <th class="numeric-cell">Fat (g)</th>
               <th class="numeric-cell">Carbs</th>

--- a/kitchen-sink/vue/src/pages/stepper.vue
+++ b/kitchen-sink/vue/src/pages/stepper.vue
@@ -253,7 +253,7 @@
     </f7-list>
 
     <f7-block-title>Manual input</f7-block-title>
-    <f7-block-header>It is possible to enter value manually from keyboard or mobile keypad. When click on input field, stepper enter into manual input mode, which allow type value from keyboar and check fractional part with defined accurancy. Click outside or enter Return key, ending manual mode.</f7-block-header>
+    <f7-block-header>It is possible to enter value manually from keyboard or mobile keypad. When click on input field, stepper enter into manual input mode, which allow type value from keyboard and check fractional part with defined accurancy. Click outside or enter Return key, ending manual mode.</f7-block-header>
     <f7-block strong class="text-align-center">
       <f7-row>
         <f7-col>

--- a/src/core/components/gauge/gauge.d.ts
+++ b/src/core/components/gauge/gauge.d.ts
@@ -9,9 +9,9 @@ export namespace Gauge {
     el : HTMLElement
     /** Dom7 instance with gauge HTML element */
     $el : Dom7Instance
-    /** Gauge generated SVH HTML element */
+    /** Gauge generated SVG HTML element */
     gaugeSvgEl : HTMLElement
-    /** Dom7 instance with generated SVH HTML element */
+    /** Dom7 instance with generated SVG HTML element */
     $gaugeSvgEl : Dom7Instance
     /** Gauge parameters */
     params : Parameters

--- a/src/core/components/stepper/stepper.d.ts
+++ b/src/core/components/stepper/stepper.d.ts
@@ -27,7 +27,7 @@ export namespace Stepper {
     formatValue?: (value: number) => string | number
     /**  */
     manualInputMode?: boolean
-    /** Enables manual input mode. This mode allows to type value from keyboar and check fractional part with defined accurancy. Also, step parameter is ignored when typing in this mode */
+    /** Enables manual input mode. This mode allows to type value from keyboard and check fractional part with defined accurancy. Also, step parameter is ignored when typing in this mode */
     decimalPoint?: number
     /** Number of digits after dot, when in manual input mode */
     buttonsEndInputMode?: boolean


### PR DESCRIPTION
Fixed typo in stepper pages and docs

And fixed small typo in data table pages and gauge docs