### PR TITLE
Picker does not have an addValue method

### DIFF
--- a/src/core/components/picker/picker.d.ts
+++ b/src/core/components/picker/picker.d.ts
@@ -37,8 +37,6 @@ export namespace Picker {
     setValue(values : unknown[], duration? : number) : void
     /** Returns current picker value */
     getValue() : unknown
-    /** Adds value to the values array. Useful in case if multiple selection is enabled (with multiple: true parameter) */
-    addValue() : void
     /** Open Picker */
     open() : void
     /** Close Picker */


### PR DESCRIPTION
On the "Picker" page of the documentation, there is also addValue in the method list:

https://github.com/framework7io/framework7-website/blob/2f3a2d71f8e7898dca2c7d9b669e86c53a87afd1/src/pug/docs/picker.pug#L347-L349

But this method doesn't exist in

https://github.com/framework7io/framework7/blob/master/src/core/components/picker/picker-class.js