### PR TITLE
Fixed wrong range DST dates selected in the datepicker

### DIFF
--- a/src/core/components/calendar/calendar-class.js
+++ b/src/core/components/calendar/calendar-class.js
@@ -711,6 +711,20 @@ class Calendar extends Framework7Class {
             )
             .addClass(addClass);
         }
+        valueDate = new Date(new Date(value[0]).getTime());
+        $wrapperEl
+            .find(
+              `.calendar-day[data-date="${valueDate.getFullYear()}-${valueDate.getMonth()}-${valueDate.getDate()}"]`,
+            )
+            .removeClass('calendar-day-selected-range')
+            .addClass('calendar-day-selected calendar-day-selected-left');
+        valueDate = new Date(new Date(value[1]).getTime());
+        $wrapperEl
+            .find(
+              `.calendar-day[data-date="${valueDate.getFullYear()}-${valueDate.getMonth()}-${valueDate.getDate()}"]`,
+            )
+            .removeClass('calendar-day-selected-range')
+            .addClass('calendar-day-selected calendar-day-selected-right');
       } else {
         for (i = 0; i < calendar.value.length; i += 1) {
           valueDate = new Date(value[i]);

--- a/src/core/components/calendar/calendar-class.js
+++ b/src/core/components/calendar/calendar-class.js
@@ -711,14 +711,14 @@ class Calendar extends Framework7Class {
             )
             .addClass(addClass);
         }
-        valueDate = new Date(new Date(value[0]).getTime());
+        valueDate = new Date(leftDate);
         $wrapperEl
             .find(
               `.calendar-day[data-date="${valueDate.getFullYear()}-${valueDate.getMonth()}-${valueDate.getDate()}"]`,
             )
             .removeClass('calendar-day-selected-range')
             .addClass('calendar-day-selected calendar-day-selected-left');
-        valueDate = new Date(new Date(value[1]).getTime());
+        valueDate = new Date(rightDate);
         $wrapperEl
             .find(
               `.calendar-day[data-date="${valueDate.getFullYear()}-${valueDate.getMonth()}-${valueDate.getDate()}"]`,


### PR DESCRIPTION
Fixed an old issue described in #1385 (daylight saving dates in the selected range).

I sent a solution only for the next version 6, because I think there will be no further updates to version 5, but the problem affects all previous versions of f7 as the solution that was proposed in #1386 caused problems with some time zones and is been reverted in https://github.com/framework7io/framework7/commit/8c9064fcfbd1bec65da8c4977cd483c57e891cb1.