### PR TITLE
Add React v17 as peer dependency

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -43,7 +43,7 @@
     "url": "https://www.patreon.com/vladimirkharlampidi"
   },
   "peerDependencies": {
-    "react": "16.x",
+    "react": "16.x || 17.x",
     "prop-types": "15.x"
   }
 }


### PR DESCRIPTION
This addresses #3754 for F7 v5.

React v17 is backwards compatible, so this should help anyone that wants to upgrade.