### PR TITLE
Svelte. Add style attribute to messagebar-sheet-image

### DIFF
--- a/src/svelte/components/messagebar-sheet-image.svelte
+++ b/src/svelte/components/messagebar-sheet-image.svelte
@@ -26,7 +26,7 @@
   }
 </script>
 
-<label class={classes} {...restProps($$restProps)}>
+<label class={classes} style={styles} {...restProps($$restProps)}>
   <input type="checkbox" {checked} on:change={onChange} />
   <i class="icon icon-checkbox" />
   <slot />


### PR DESCRIPTION
Adding back style attribute for src/svelte/components/messagebar-sheet-image.svelte
Changes were introduced in commit https://github.com/framework7io/framework7/commit/2100a99d50101e46e8a64402a7cf20a9d63fa920#diff-5714ba4af35367da3ddaf887a43a5f6f117308b9dbfc12459df8d7fc22c11cfb.

Related Issue - https://github.com/framework7io/framework7/issues/3776