### PR TITLE
Core: Vdom - fix custom component in template7 each helper err

### DIFF
--- a/src/core/modules/component/vdom.js
+++ b/src/core/modules/component/vdom.js
@@ -71,7 +71,7 @@ const destroyCustomComponent = (vnode) => {
   // eslint-disable-next-line
   const component = vnode && vnode.elm && vnode.elm.__component__;
 
-  if (component) {
+  if (component && Object.keys(component) > 0) {
     const { el, $el } = component;
     if (vnode.data && vnode.data.on && $el) {
       Object.keys(vnode.data.on).forEach((eventName) => {


### PR DESCRIPTION
I think there is an error in the vnode.
An error occurred when I wrote the code as follows. ( in `blahblah.f7.html`)
```html
<template>
 ...
{{#each items}}
  <custom-component></custom-compoent>
{{/each}}
...
</template>
```

It's a problem when you leave the page where the above code is written.

![image](https://user-images.githubusercontent.com/72075148/100858421-4bd52080-34d1-11eb-8fca-f63384d3d286.png)

I think an exceptional situation occurs when the custom components are in template7 each helper when they are deleted and created.
