### PR TITLE
#3788 FIX: [react] pass props from route options for initial route

### DIFF
--- a/src/react/shared/get-router-initial-component.js
+++ b/src/react/shared/get-router-initial-component.js
@@ -4,6 +4,12 @@ export const getRouterInitialComponent = (router, initialComponent) => {
   let initialComponentData;
   const { initialUrl } = router.getInitialUrl();
   const initialRoute = router.findMatchingRoute(initialUrl);
+  let routeProps;
+
+  if (initialRoute.route.options) {
+    routeProps = initialRoute.route.options.props;
+  }
+
   if (
     initialRoute &&
     initialRoute.route &&
@@ -18,6 +24,7 @@ export const getRouterInitialComponent = (router, initialComponent) => {
       props: {
         f7route: initialRoute,
         f7router: router,
+        ...routeProps,
         ...initialRoute.params,
       },
     };


### PR DESCRIPTION
getRouterInitialComponent() function sets up components for the default route.
Currently, props configured on the route options are not passed when creating
the initial component, so are not available on first render. (props are
available only on subsequent navigation). This change fixes the issue by copying
props from route options when setting up initial component

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/framework7io/framework7/blob/master/.github/CONTRIBUTING.md) when submitting a pull request.
