### PR TITLE
New method clearValue()

### DIFF
--- a/src/core/components/text-editor/text-editor-class.js
+++ b/src/core/components/text-editor/text-editor-class.js
@@ -152,6 +152,15 @@ class TextEditor extends Framework7Class {
     const self = this;
     return self.value;
   }
+  
+  clearValue() {
+    const self = this;
+    self.setValue('');
+    if (self.params.placeholder && !self.$contentEl.html()) {
+      self.insertPlaceholder();
+    }
+    return self;
+  }
 
   createLink() {
     const self = this;


### PR DESCRIPTION
The clearValue() method is similar to the setValue() method except that it displays the placeholder when the value is null and the placeholder is not already present.
Note that another solution would be to modify the setValue() method so it displays the placeholder when the value is set to null.