### PR TITLE
title -> footer typofix

### DIFF
--- a/src/vue/components/card.vue
+++ b/src/vue/components/card.vue
@@ -35,7 +35,7 @@
       <slot name="content" />
     </f7-card-content>
     <f7-card-footer v-if="hasFooter">
-      {{ title }}
+      {{ footer }}
       <slot name="footer" />
     </f7-card-footer>
     <slot />


### PR DESCRIPTION
A small typofix to render footer content to card footer placeholder (instead of title) in f7-vue.

Thanks,
Bálint