### PR TITLE
[Fix] Kitchen Sink - iOS overscroll/bounce

### DIFF
--- a/kitchen-sink/core/css/app.css
+++ b/kitchen-sink/core/css/app.css
@@ -11,6 +11,13 @@
     url(../fonts/MaterialIcons-Regular.ttf) format('truetype');
 }
 
+html,
+body {
+  /* prevent ios overscroll/bounce: https://github.com/framework7io/framework7-website/issues/491 */
+  position: fixed;
+  overflow: hidden;
+}
+
 .material-icons {
   font-family: 'Material Icons';
   font-weight: normal;


### PR DESCRIPTION
Solve this issue: https://github.com/framework7io/framework7-website/issues/491
As you can see in the video of the issue the whole website bounces and you can't scroll the inner content.
Only after you focus the inner content you can scroll it.
This can be prevented by adding this css to ``kitchen-sink/core/css/app.css``:
```css
html,
body {
  position: fixed;
  overflow: hidden;
}
```

Solution by: https://www.bram.us/2016/05/02/prevent-overscroll-bounce-in-ios-mobilesafari-pure-css/