### PR TITLE
Add typing for button groups on action sheet API

### DIFF
--- a/src/core/components/actions/actions.d.ts
+++ b/src/core/components/actions/actions.d.ts
@@ -65,7 +65,7 @@ export namespace Actions {
     /** Whether the Action Sheet should be opened/closed with animation or not. Can be overwritten in .open() and .close() methods*/
     animate?: boolean;
     /** Action sheet groups/buttons. In this case Actions layout will be generated dynamically based on passed groups and buttons. In case of groups it should array where each item represent array with buttons for group.*/
-    buttons?: Button[];
+    buttons?: Button[] | Button[][];
     /** Enables grid buttons layout*/
     grid?: boolean;
     /** When enabled, action sheet will be converted to Popover on large screens.*/


### PR DESCRIPTION
Add typing for button groups on programmatically calling action sheet API with `f7.actions.create({})`

Per issue: https://github.com/framework7io/framework7/issues/3884#issue-881514177
