### PR TITLE
Fix (data-table): added missing TS DOM Events definitions

### DIFF
--- a/src/core/components/data-table/data-table.d.ts
+++ b/src/core/components/data-table/data-table.d.ts
@@ -38,6 +38,12 @@ export namespace DataTable {
     };
   }
   interface AppParams {}
+  interface DomEvents {
+    /** Event will be triggered data table sort changed */
+    'datatable:sort': () => void;
+    /** Event will be triggered right before Data Table instance will be destroyed */
+    'datatable:beforedestroy': () => void;
+  }
   interface AppEvents {
     /** Event will be triggered data table sort changed. As an argument event handler receives data table instance and new sort order (asc or desc) */
     dataTableSort: (dataTable: DataTable, sort: string) => void;


### PR DESCRIPTION
Update data-table.d.ts

@nolimits4web Please, you could take a look at these too: https://github.com/framework7io/framework7-website/issues/502 and https://github.com/framework7io/framework7-website/pull/500

Thanks