### PR TITLE
fix(react messages): fixed issue for scrollMessagesOnEdge params

### DIFF
--- a/src/react/components/messages.jsx
+++ b/src/react/components/messages.jsx
@@ -139,6 +139,29 @@ const Messages = forwardRef((props, ref) => {
       ) {
         f7Messages.current.scroll();
       }
+      if (
+        childrenBeforeUpdated.current !== childrenAfterUpdated &&
+        f7Messages.current.scroll &&
+        scrollMessages
+      ) {
+        if (scrollMessagesOnEdge) {
+          // Define scroll positions before new messages added
+          const scrollHeightBefore = f7Messages.current.pageContentEl.scrollHeight;
+          const heightBefore = f7Messages.current.pageContentEl.offsetHeight;
+          const scrollBefore = f7Messages.current.pageContentEl.scrollTop;
+
+          let onEdge = false;
+          if (newMessagesFirst && scrollBefore === 0) {
+            onEdge = true;
+          }
+          if (!newMessagesFirst && scrollBefore - (scrollHeightBefore - heightBefore) >= -10) {
+            onEdge = true;
+          }
+          if (onEdge) f7Messages.current.scroll();
+        } else {
+          f7Messages.current.scroll();
+        }
+      }
     }
     childrenBeforeUpdated.current = childrenAfterUpdated;
   });


### PR DESCRIPTION
## Why?
With 'scrollMessages' true and 'scrollMessagesOnEdge' true, scroll slightly up and down when you send a message.

The value of "scrollMessagesOnEdge" and the scroll position of the current page are dropped to the bottom without checking.

## How?
I added a 'if statement' to check the 'scrollMessageOnEdge' parameter and the Edge.

## Anything Else?
I think wee need to think more about  'typingMessage' and 'newMessagesFirst'.