### PR TITLE
fix(get-device): allow recognition of Chrome's Android emulator on Windows as android

### DIFF
--- a/src/core/shared/get-device.js
+++ b/src/core/shared/get-device.js
@@ -79,7 +79,7 @@ function calcDevice({ userAgent } = {}) {
   device.firefox = firefox;
 
   // Android
-  if (android && !windows) {
+  if (android) {
     device.os = 'android';
     device.osVersion = android[2];
     device.android = true;


### PR DESCRIPTION
Chrome's device emulator manipulates user agent string according to the selected device, however device detector makes use of window.navigator.platform as well, which seems to be merely untouched by Chrome's device emulator.
The distinction in device detector used by calcDevice() [&& !windows] prevents recognizing the emulated android device as 'android' and the app keeps running in 'desktop' mode, which makes things difficult especially with auto-theming.
Looking at the history of get-device.js this distinction has been brewing since the early days of v1, but I just couldn't figure out the intention behind - and doesn't seem to have any effect e.g. with Chrome on Linux, or Firefox device emu on Windows: both correctly detected as android devices.