### PR TITLE
[Fix] react messages.jsx TS bug fix

### DIFF
--- a/src/react/components/messages.jsx
+++ b/src/react/components/messages.jsx
@@ -29,7 +29,7 @@ import { Messages } from 'framework7/types';
   customClassMessageRule? : Function
   renderMessage? : Function
   init? : boolean
-  ref?: React.MutableRefObject<{el: HTMLElement | null; f7Messages: Messages.Messages}>;
+  ref?: React.MutableRefObject<{el: HTMLElement | null; f7Messages: () => Messages.Messages}>;
   COLOR_PROPS
 */
 


### PR DESCRIPTION
Found typescript problem with `messages.d.ts`.

```js
  ref?: React.MutableRefObject<{el: HTMLElement | null; f7Messages: Messages.Messages}>;
```

which should be

```js
  ref?: React.MutableRefObject<{el: HTMLElement | null; f7Messages: () => Messages.Messages}>;
```

`f7Messages` is getter function for f7Messages object. 

So, I fixed `messages.jsx` that might generate `messages.d.ts` according to my understanding (I'm not sure about this).

Please excuse me if I make incorrect or wrong pull request since it's my first PR to open source project. 
