### PR TITLE
Sortable `List` nested `ListInput`'s behavior

### DIFF
--- a/src/react/components/list-item.jsx
+++ b/src/react/components/list-item.jsx
@@ -330,7 +330,7 @@ const ListItem = forwardRef((props, ref) => {
   let itemContentEl;
 
   const isMediaComputed = mediaItem || mediaList || listIsMedia;
-  const isSortableComputed = sortable || listIsSortable;
+  const isSortableComputed = sortable === true || sortable === false ? sortable : listIsSortable;
   const isSortableOppositeComputed =
     isSortableComputed && (sortableOpposite || listIsSortableOpposite);
 

--- a/src/svelte/components/list-input.svelte
+++ b/src/svelte/components/list-input.svelte
@@ -99,7 +99,7 @@
       ListContext = newValue || {};
     }) || {};
 
-  $: isSortable = sortable || ListContext.listIsSortable;
+  $: isSortable = sortable ?? ListContext.listIsSortable;
   $: isSortableOpposite = sortableOpposite || ListContext.listIsSortableOpposite;
 
   function domValue() {

--- a/src/svelte/components/list-input.svelte
+++ b/src/svelte/components/list-input.svelte
@@ -99,7 +99,7 @@
       ListContext = newValue || {};
     }) || {};
 
-  $: isSortable = sortable ?? ListContext.listIsSortable;
+  $: isSortable = sortable === true || sortable === false ? sortable : ListContext.listIsSortable;
   $: isSortableOpposite = sortableOpposite || ListContext.listIsSortableOpposite;
 
   function domValue() {

--- a/src/vue/components/list-item.vue
+++ b/src/vue/components/list-item.vue
@@ -444,7 +444,9 @@ export default {
     );
 
     const isMediaComputed = computed(() => props.mediaItem || props.mediaList || listIsMedia.value);
-    const isSortableComputed = computed(() => props.sortable || listIsSortable.value);
+    const isSortableComputed = computed(() =>
+      props.sortable === true || props.sortable === false ? props.sortable : listIsSortable.value,
+    );
     const isSortableOppositeComputed = computed(
       () => isSortableComputed.value && (props.sortableOpposite || listIsSortableOpposite.value),
     );


### PR DESCRIPTION
Bug: `ListInput`'s with `sortable={false}` were rendering the sortable handler when nested inside a sortable list.
This change allows `ListInput`'s sortable value to take precedence over a parent list whenever it's set, otherwise it behaves like usual.