### PR TITLE
vue(sortable): fix `sortableMove` arguments

### DIFF
--- a/src/vue/components/list.vue
+++ b/src/vue/components/list.vue
@@ -91,7 +91,7 @@ export default {
     };
     const onSortableMove = (el, listEl) => {
       if (elRef.value !== listEl) return;
-      emit(props, 'sortable:move', el, listEl);
+      emit('sortable:move', el, listEl);
     };
 
     useTab(elRef, emit);


### PR DESCRIPTION
First argument of `emit` should be the event name. Currently, the sorting provoke a fatal error (it can be observed on the vue kitchensink).
