### PR TITLE
fix(types): add missing params to notification and toast open/close methods

### DIFF
--- a/src/core/components/notification/notification.d.ts
+++ b/src/core/components/notification/notification.d.ts
@@ -13,9 +13,9 @@ export namespace Notification {
     params: Parameters;
 
     /** Open notification */
-    open(): Notification;
+    open(animate?: boolean): Notification;
     /** Close notification */
-    close(): Notification;
+    close(animate?: boolean): Notification;
   }
 
   interface Parameters {
@@ -88,10 +88,10 @@ export namespace Notification {
       get(el: HTMLElement | CSSSelector): Notification;
 
       /** open Notification */
-      open(el: HTMLElement | CSSSelector): Notification;
+      open(el: HTMLElement | CSSSelector, animate?: boolean): Notification;
 
       /** closes Notification */
-      close(el: HTMLElement | CSSSelector): Notification;
+      close(el: HTMLElement | CSSSelector, animate?: boolean): Notification;
     };
   }
   interface AppParams {

--- a/src/core/components/toast/toast.d.ts
+++ b/src/core/components/toast/toast.d.ts
@@ -60,9 +60,9 @@ export namespace Toast {
     params: Parameters;
 
     /** Open toast */
-    open(): Toast;
+    open(animate?: boolean): Toast;
     /** Close toast */
-    close(): Toast;
+    close(animate?: boolean): Toast;
     /** Destroy toast */
     destroy(): void;
   }


### PR DESCRIPTION
These types are not documented on the website, but are supported in code. Both these extend the `Modal` base class, which implements this support for this param.

It's very helpful especially on close to safely and immediately dispose the toast without waiting for the animation to complete.

See:
* https://github.com/framework7io/framework7/blob/master/src/core/components/notification/notification-class.js#L7
* https://github.com/framework7io/framework7/blob/master/src/core/components/toast/toast-class.js#L8
* https://github.com/framework7io/framework7/blob/master/src/core/components/modal/modal-class.js#L73
* https://github.com/framework7io/framework7/blob/master/src/core/components/modal/modal-class.js#L159