### PR TITLE
Do not clone deep options in (router) back

### DIFF
--- a/src/core/modules/router/back.js
+++ b/src/core/modules/router/back.js
@@ -16,6 +16,7 @@ function backward(router, el, backwardOptions) {
   const view = router.view;
 
   const options = extend(
+    false,
     {
       animate: router.params.animate,
       browserHistory: true,


### PR DESCRIPTION
The same as #2739, but for back

Same reason:

In the process of cloning options in back function, the the route instance is replaced by a copy, so the route instance stored in router.currentRoute is different from the one passed to route async handler.

The proposed change is safe since options variable is not mutated at all.

It is also more performant