### PR TITLE
Do not select stacked pages when querying for previous page in router back

### DIFF
--- a/src/core/modules/router/back.js
+++ b/src/core/modules/router/back.js
@@ -734,7 +734,7 @@ function back(...args) {
   }
   let $previousPage = router.$el
     .children('.page-current')
-    .prevAll('.page-previous:not(.page-master)')
+    .prevAll('.page-previous:not(.stacked):not(.page-master)')
     .eq(0);
 
   let skipMaster;


### PR DESCRIPTION
Fixes #3975 

This change does not select .stacked pages when determining previous page.

Uses the same selector used e.g. in https://github.com/framework7io/framework7/blob/master/src/core/modules/router/back.js#L343