### PR TITLE
fix(react): typing error(Actions, Range)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6129,6 +6129,16 @@
       "license": "ISC",
       "optional": true
     },
+    "node_modules/fsevents/node_modules/ini": {
+      "version": "1.3.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/fsevents/node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
       "dev": true,
@@ -17335,6 +17345,12 @@
         },
         "inherits": {
           "version": "2.0.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ini": {
+          "version": "1.3.5",
           "bundled": true,
           "dev": true,
           "optional": true

--- a/src/core/modules/component/component.d.ts
+++ b/src/core/modules/component/component.d.ts
@@ -46,9 +46,9 @@ export interface ComponentContext {
   /** Render function */
   $render: ComponentRender;
   /** Attach event handler to component root DOM element */
-  $on: (eventName, handler: () => void) => void;
+  $on: (eventName: string, handler: () => void) => void;
   /** Attach event handler to component root DOM element that will be executed only once */
-  $once: (eventName, handler: () => void) => void;
+  $once: (eventName: string, handler: () => void) => void;
   /** Hook called right before component will be added to DOM */
   $onBeforeMount: (callback: () => void) => void;
   /** Hook called right after component has been added to DOM */

--- a/src/react/components/actions.jsx
+++ b/src/react/components/actions.jsx
@@ -30,7 +30,7 @@ import { Actions } from 'framework7/types';
   onActionsClose? : (instance?: Actions.Actions) => void
   onActionsClosed? : (instance?: Actions.Actions) => void
   containerEl? : string | object
-  ref?: React.MutableRefObject<{el: HTMLElement | null; f7Actions: () => Actions}>;
+  ref?: React.MutableRefObject<{el: HTMLElement | null; f7Actions: () => Actions.Actions}>;
   COLOR_PROPS
 */
 

--- a/src/react/components/range.jsx
+++ b/src/react/components/range.jsx
@@ -36,7 +36,7 @@ import { Range } from 'framework7/types';
   COLOR_PROPS
   onRangeChange? : (val?: any) => void
   onRangeChanged? : (val?: any) => void
-  ref?: React.MutableRefObject<{el: HTMLElement | null; f7Range: () => Range.Rage}>;
+  ref?: React.MutableRefObject<{el: HTMLElement | null; f7Range: () => Range.Range}>;
 */
 
 const Range = forwardRef((props, ref) => {


### PR DESCRIPTION
src/modules/components/component.d.ts:
```ts
...
 $on: (eventName: string, handler: () => void) => void;  // eventName add type
 $once: (eventName: string, handler: () => void) => void;  // eventName add type
...
```
src/react/components/actions.jsx: `Actions` is namespace, can not use it as type;
src/react/components/range.jsx: `Range.Rage` cause build error
