### PR TITLE
Fix preloader animation for iOS 15.4

### DIFF
--- a/src/core/components/preloader/preloader-ios.less
+++ b/src/core/components/preloader/preloader-ios.less
@@ -29,6 +29,9 @@
   });
 }
 @keyframes ios-preloader-spin {
+  0% {
+    transform: rotate(0deg);
+  }
   100% {
     transform: rotate(360deg);
   }


### PR DESCRIPTION
Fixes preloader animation for iOS 15.4 as referenced https://github.com/framework7io/framework7/issues/3998
