### PR TITLE
Add export for props interface

### DIFF
--- a/scripts/build-react-typings.js
+++ b/scripts/build-react-typings.js
@@ -51,7 +51,7 @@ function generateComponentTypings(componentName, fileContent) {
 import * as React from 'react';
 // IMPORTS
 
-interface ${componentName}Props${propsExtends ? ` extends ${propsExtends.trim()}` : ''} {
+export interface ${componentName}Props${propsExtends ? ` extends ${propsExtends.trim()}` : ''} {
   slot?: string;
   // PROPS
 }


### PR DESCRIPTION
Adds export for props interface so there will be much easier to add types for custom conponents based on framework7 react components.
Full description here - https://github.com/framework7io/framework7/issues/4024