### PR TITLE
Make children prop explicit for react 18 support

### DIFF
--- a/src/react/components/accordion-content.jsx
+++ b/src/react/components/accordion-content.jsx
@@ -7,6 +7,7 @@ import { colorClasses } from '../shared/mixins.js';
   className: string;
   style: React.CSSProperties;
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
   COLOR_PROPS
 */
 

--- a/src/react/components/accordion-item.jsx
+++ b/src/react/components/accordion-item.jsx
@@ -16,6 +16,7 @@ import { f7, f7ready } from '../shared/f7.js';
   onAccordionClose? : (...args: any[]) => void
   onAccordionClosed? : (...args: any[]) => void
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
   COLOR_PROPS
 */
 

--- a/src/react/components/accordion-toggle.jsx
+++ b/src/react/components/accordion-toggle.jsx
@@ -7,6 +7,7 @@ import { colorClasses } from '../shared/mixins.js';
   className: string;
   style: React.CSSProperties;
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
   COLOR_PROPS
 */
 

--- a/src/react/components/accordion.jsx
+++ b/src/react/components/accordion.jsx
@@ -8,6 +8,7 @@ import { colorClasses } from '../shared/mixins.js';
   style: React.CSSProperties;
   accordionOpposite: boolean;
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
   COLOR_PROPS
 */
 

--- a/src/react/components/actions-button.jsx
+++ b/src/react/components/actions-button.jsx
@@ -11,6 +11,7 @@ import { f7 } from '../shared/f7.js';
   close: boolean;
   onClick? : (event?: any) => void
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
   COLOR_PROPS
 */
 

--- a/src/react/components/actions-group.jsx
+++ b/src/react/components/actions-group.jsx
@@ -7,6 +7,7 @@ import { colorClasses } from '../shared/mixins.js';
   className: string;
   style: React.CSSProperties;
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
   COLOR_PROPS
 */
 

--- a/src/react/components/actions-label.jsx
+++ b/src/react/components/actions-label.jsx
@@ -9,6 +9,7 @@ import { colorClasses } from '../shared/mixins.js';
   bold: boolean;
   onClick?: (event?: any) => void
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
   COLOR_PROPS
 */
 

--- a/src/react/components/actions.jsx
+++ b/src/react/components/actions.jsx
@@ -31,6 +31,7 @@ import { Actions } from 'framework7/types';
   onActionsClosed? : (instance?: Actions.Actions) => void
   containerEl? : string | object
   ref?: React.MutableRefObject<{el: HTMLElement | null; f7Actions: () => Actions.Actions}>;
+  children?: React.ReactNode;
   COLOR_PROPS
 */
 

--- a/src/react/components/app.jsx
+++ b/src/react/components/app.jsx
@@ -18,6 +18,7 @@ import { f7init, f7 } from '../shared/f7.js';
   className?: string;
   style?: React.CSSProperties;
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
   COLOR_PROPS
 */
 

--- a/src/react/components/appbar.jsx
+++ b/src/react/components/appbar.jsx
@@ -12,6 +12,7 @@ import { colorClasses } from '../shared/mixins.js';
   innerClass: string;
   innerClassName: string;
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
   COLOR_PROPS
 */
 

--- a/src/react/components/area-chart.jsx
+++ b/src/react/components/area-chart.jsx
@@ -24,6 +24,7 @@ import { f7 } from '../shared/f7.js';
   formatTooltipDataset?: (label: any, value: number, color: string) => string;
   onSelect? : (index: number | null) => void
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
 */
 
 const AreaChart = forwardRef((props, ref) => {

--- a/src/react/components/badge.jsx
+++ b/src/react/components/badge.jsx
@@ -18,6 +18,7 @@ f7Tooltip: Tooltip.Tooltip
   tooltip: string;
   tooltipTrigger: string;
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
   COLOR_PROPS
 */
 

--- a/src/react/components/block-footer.jsx
+++ b/src/react/components/block-footer.jsx
@@ -7,6 +7,7 @@ import { colorClasses } from '../shared/mixins.js';
   className: string;
   style: React.CSSProperties;
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
   COLOR_PROPS
 */
 

--- a/src/react/components/block-header.jsx
+++ b/src/react/components/block-header.jsx
@@ -7,6 +7,7 @@ import { colorClasses } from '../shared/mixins.js';
   className: string;
   style: React.CSSProperties;
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
   COLOR_PROPS
 */
 

--- a/src/react/components/block-title.jsx
+++ b/src/react/components/block-title.jsx
@@ -9,6 +9,7 @@ import { colorClasses } from '../shared/mixins.js';
   large?: boolean;
   medium?: boolean;
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
   COLOR_PROPS
 */
 

--- a/src/react/components/block.jsx
+++ b/src/react/components/block.jsx
@@ -26,6 +26,7 @@ import { useTab } from '../shared/use-tab.js';
   onTabShow?: (el?: HTMLElement) => void
   onTabHide?: (el?: HTMLElement) => void
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
   COLOR_PROPS
 */
 

--- a/src/react/components/breadcrumbs-collapsed.jsx
+++ b/src/react/components/breadcrumbs-collapsed.jsx
@@ -7,6 +7,7 @@ import { classNames, getExtraAttrs, emit } from '../shared/utils.js';
   style?: React.CSSProperties;
   onClick? : (event?: any) => void;
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
 */
 
 const BreadcrumbsCollapsed = forwardRef((props, ref) => {

--- a/src/react/components/breadcrumbs-item.jsx
+++ b/src/react/components/breadcrumbs-item.jsx
@@ -8,6 +8,7 @@ import { classNames, getExtraAttrs, emit } from '../shared/utils.js';
   onClick? : (event?: any) => void;
   active?: boolean;
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
 */
 
 const BreadcrumbsItem = forwardRef((props, ref) => {

--- a/src/react/components/breadcrumbs-separator.jsx
+++ b/src/react/components/breadcrumbs-separator.jsx
@@ -6,6 +6,7 @@ import { classNames, getExtraAttrs } from '../shared/utils.js';
   className?: string;
   style?: React.CSSProperties;
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
 */
 
 const BreadcrumbsSeparator = forwardRef((props, ref) => {

--- a/src/react/components/breadcrumbs.jsx
+++ b/src/react/components/breadcrumbs.jsx
@@ -6,6 +6,7 @@ import { classNames, getExtraAttrs } from '../shared/utils.js';
   className?: string;
   style?: React.CSSProperties;
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
 */
 
 const Breadcrumbs = forwardRef((props, ref) => {

--- a/src/react/components/button.jsx
+++ b/src/react/components/button.jsx
@@ -57,6 +57,7 @@ import Preloader from './preloader.js';
   loading?: boolean;
   onClick? : (event?: any) => void;
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
   COLOR_PROPS
   ICON_PROPS
   ROUTER_PROPS

--- a/src/react/components/card-content.jsx
+++ b/src/react/components/card-content.jsx
@@ -8,6 +8,7 @@ import { colorClasses } from '../shared/mixins.js';
   style: React.CSSProperties;
   padding: boolean;
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
   COLOR_PROPS
 */
 

--- a/src/react/components/card-footer.jsx
+++ b/src/react/components/card-footer.jsx
@@ -7,6 +7,7 @@ import { colorClasses } from '../shared/mixins.js';
   className: string;
   style: React.CSSProperties;
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
   COLOR_PROPS
 */
 

--- a/src/react/components/card-header.jsx
+++ b/src/react/components/card-header.jsx
@@ -7,6 +7,7 @@ import { colorClasses } from '../shared/mixins.js';
   className: string;
   style: React.CSSProperties;
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
   COLOR_PROPS
 */
 

--- a/src/react/components/card.jsx
+++ b/src/react/components/card.jsx
@@ -39,6 +39,7 @@ import { watchProp } from '../shared/watch-prop.js';
   onCardClose? : (el?: HTMLElement) => void
   onCardClosed? : (el?: HTMLElement, pageEl?: HTMLElement) => void
   ref?: React.MutableRefObject<{el: HTMLElement | null; open: () => void; close: () => void}>;
+  children?: React.ReactNode;
   COLOR_PROPS
 */
 

--- a/src/react/components/checkbox.jsx
+++ b/src/react/components/checkbox.jsx
@@ -16,6 +16,7 @@ import { colorClasses } from '../shared/mixins.js';
   COLOR_PROPS
   onChange? : (event?: any) => void
   ref?: React.MutableRefObject<{el: HTMLElement | null; inputEl: HTMLElement | null}>;
+  children?: React.ReactNode;
 */
 
 const Checkbox = forwardRef((props, ref) => {

--- a/src/react/components/chip.jsx
+++ b/src/react/components/chip.jsx
@@ -19,6 +19,7 @@ import { useIcon } from '../shared/use-icon.js';
   onClick? : (event?: any) => void
   onDelete? : (event?: any) => void
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
   COLOR_PROPS
   ICON_PROPS
 */

--- a/src/react/components/col.jsx
+++ b/src/react/components/col.jsx
@@ -21,6 +21,7 @@ import { f7ready, f7 } from '../shared/f7.js';
   onClick? : (event?: any) => void
   onGridResize? : (...args: any[]) => void
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
   COLOR_PROPS
 */
 

--- a/src/react/components/fab-backdrop.jsx
+++ b/src/react/components/fab-backdrop.jsx
@@ -6,6 +6,7 @@ import { getExtraAttrs, classNames } from '../shared/utils.js';
   className?: string;
   style?: React.CSSProperties;
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
 */
 
 const FabBackdrop = forwardRef((props, ref) => {

--- a/src/react/components/fab-button.jsx
+++ b/src/react/components/fab-button.jsx
@@ -14,6 +14,7 @@ import { useTooltip } from '../shared/use-tooltip.js';
   tooltipTrigger? : string;
   onClick? : (event?: any) => void;
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
   COLOR_PROPS
 */
 

--- a/src/react/components/fab-buttons.jsx
+++ b/src/react/components/fab-buttons.jsx
@@ -8,6 +8,7 @@ import { colorClasses } from '../shared/mixins.js';
   style?: React.CSSProperties;
   position?: string;
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
   COLOR_PROPS
 */
 

--- a/src/react/components/fab.jsx
+++ b/src/react/components/fab.jsx
@@ -16,6 +16,7 @@ import { useTooltip } from '../shared/use-tooltip.js';
   tooltipTrigger? : string;
   onClick? : (event?: any) => void;
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
   COLOR_PROPS
 */
 

--- a/src/react/components/gauge.jsx
+++ b/src/react/components/gauge.jsx
@@ -22,6 +22,7 @@ import { classNames, getExtraAttrs } from '../shared/utils.js';
   labelFontSize? : number | string
   labelFontWeight? : number | string
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
 */
 
 const Gauge = forwardRef((props, ref) => {

--- a/src/react/components/icon.jsx
+++ b/src/react/components/icon.jsx
@@ -18,6 +18,7 @@ import { useTheme } from '../shared/use-theme.js';
   tooltipTrigger? : string;
   size? : string | number;
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
   COLOR_PROPS
 */
 

--- a/src/react/components/input.jsx
+++ b/src/react/components/input.jsx
@@ -74,6 +74,7 @@ import { Calendar, ColorPicker, TextEditor } from 'framework7/types';
   onChange? : (...args: any[]) => void
   onTextEditorChange? : (...args: any[]) => void
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
 */
 
 const Input = forwardRef((props, ref) => {

--- a/src/react/components/link.jsx
+++ b/src/react/components/link.jsx
@@ -44,6 +44,7 @@ import { SmartSelect } from 'framework7/types';
   ROUTER_PROPS
   onClick? : (event?: any) => void
   ref?: React.MutableRefObject<{el: HTMLElement | null; f7SmartSelect: () => SmartSelect.SmartSelect}>;
+  children?: React.ReactNode;
 */
 
 const Link = forwardRef((props, ref) => {

--- a/src/react/components/list-button.jsx
+++ b/src/react/components/list-button.jsx
@@ -28,6 +28,7 @@ import { useRouteProps } from '../shared/use-route-props.js';
   ACTIONS_PROPS
   onClick? : (event?: any) => void
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
 */
 
 const ListButton = forwardRef((props, ref) => {

--- a/src/react/components/list-group.jsx
+++ b/src/react/components/list-group.jsx
@@ -13,6 +13,7 @@ import { ListContext } from '../shared/list-context.js';
   sortableTapHold? : boolean
   sortableMoveElements? : boolean
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
   COLOR_PROPS
 */
 

--- a/src/react/components/list-index.jsx
+++ b/src/react/components/list-index.jsx
@@ -20,6 +20,7 @@ import { watchProp } from '../shared/watch-prop.js';
   COLOR_PROPS
   onListIndexSelect? : (itemContent?: any, itemIndex?: any) => void
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
 */
 
 const ListIndex = forwardRef((props, ref) => {

--- a/src/react/components/list-input.jsx
+++ b/src/react/components/list-input.jsx
@@ -78,6 +78,7 @@ import { Calendar, ColorPicker, TextEditor } from 'framework7/types';
   onChange? : (...args: any[]) => void
   onTextEditorChange? : (...args: any[]) => void
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
 */
 
 const ListInput = forwardRef((props, ref) => {

--- a/src/react/components/list-item-cell.jsx
+++ b/src/react/components/list-item-cell.jsx
@@ -7,6 +7,7 @@ import { colorClasses } from '../shared/mixins.js';
   className?: string;
   style?: React.CSSProperties;
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
   COLOR_PROPS
 */
 

--- a/src/react/components/list-item-row.jsx
+++ b/src/react/components/list-item-row.jsx
@@ -7,6 +7,7 @@ import { colorClasses } from '../shared/mixins.js';
   className?: string;
   style?: React.CSSProperties;
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
   COLOR_PROPS
 */
 

--- a/src/react/components/list-item.jsx
+++ b/src/react/components/list-item.jsx
@@ -89,6 +89,7 @@ import { SmartSelect } from 'framework7/types';
   onAccordionOpened? : (...args: any[]) => void
   onChange? : (event?: any) => void
   ref?: React.MutableRefObject<{el: HTMLElement | null; f7SmartSelect: () => SmartSelect.SmartSelect}>;
+  children?: React.ReactNode;
 */
 
 /*

--- a/src/react/components/list.jsx
+++ b/src/react/components/list.jsx
@@ -68,6 +68,7 @@ import { VirtualList } from 'framework7/types';
   onTabShow? : (el?: HTMLElement) => void
   onTabHide? : (el?: HTMLElement) => void
   ref?: React.MutableRefObject<{el: HTMLElement | null; f7VirtualList: () => VirtualList.VirtualList}>;
+  children?: React.ReactNode;
 */
 
 const List = forwardRef((props, ref) => {

--- a/src/react/components/login-screen-title.jsx
+++ b/src/react/components/login-screen-title.jsx
@@ -7,6 +7,7 @@ import { colorClasses } from '../shared/mixins.js';
   className?: string;
   style?: React.CSSProperties;
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
   COLOR_PROPS
 */
 

--- a/src/react/components/login-screen.jsx
+++ b/src/react/components/login-screen.jsx
@@ -21,6 +21,7 @@ import { LoginScreen } from 'framework7/types';
   onLoginScreenClose? : (instance: LoginScreen.LoginScreen) => void
   onLoginScreenClosed? : (instance: LoginScreen.LoginScreen) => void
   ref?: React.MutableRefObject<{el: HTMLElement | null; f7LoginScreen: () => LoginScreen.LoginScreen}>;
+  children?: React.ReactNode;
   COLOR_PROPS
 */
 

--- a/src/react/components/menu-dropdown-item.jsx
+++ b/src/react/components/menu-dropdown-item.jsx
@@ -23,6 +23,7 @@ import { useRouteProps } from '../shared/use-route-props.js';
   ACTIONS_PROPS
   onClick? : (event?: any) => void;
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
 */
 
 const MenuDropdownItem = forwardRef((props, ref) => {

--- a/src/react/components/menu-dropdown.jsx
+++ b/src/react/components/menu-dropdown.jsx
@@ -12,6 +12,7 @@ import { colorClasses } from '../shared/mixins.js';
   center? : boolean
   right? : boolean
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
   COLOR_PROPS
 */
 

--- a/src/react/components/menu-item.jsx
+++ b/src/react/components/menu-item.jsx
@@ -33,6 +33,7 @@ import { useTooltip } from '../shared/use-tooltip.js';
   onMenuOpened? : (el?: HTMLElement) => void;
   onMenuClosed? : (el?: HTMLElement) => void;
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
 */
 
 const MenuItem = forwardRef((props, ref) => {

--- a/src/react/components/menu.jsx
+++ b/src/react/components/menu.jsx
@@ -7,6 +7,7 @@ import { colorClasses } from '../shared/mixins.js';
   className?: string;
   style?: React.CSSProperties;
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
   COLOR_PROPS
 */
 

--- a/src/react/components/message.jsx
+++ b/src/react/components/message.jsx
@@ -32,6 +32,7 @@ import { colorClasses } from '../shared/mixins.js';
   onClickFooter? : (event?: any) => void
   onClickBubble? : (event?: any) => void
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
 */
 
 const Message = forwardRef((props, ref) => {

--- a/src/react/components/messagebar-attachment.jsx
+++ b/src/react/components/messagebar-attachment.jsx
@@ -12,6 +12,7 @@ import { colorClasses } from '../shared/mixins.js';
   onAttachmentClick? : (event?: any) => void
   onAttachmentDelete? : (event?: any) => void
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
 */
 
 const MessagebarAttachment = forwardRef((props, ref) => {

--- a/src/react/components/messagebar-attachments.jsx
+++ b/src/react/components/messagebar-attachments.jsx
@@ -7,6 +7,7 @@ import { colorClasses } from '../shared/mixins.js';
   className?: string;
   style?: React.CSSProperties;
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
   COLOR_PROPS
 */
 

--- a/src/react/components/messagebar-sheet-image.jsx
+++ b/src/react/components/messagebar-sheet-image.jsx
@@ -13,6 +13,7 @@ import { colorClasses } from '../shared/mixins.js';
   onUnchecked? : (event?: any) => void
   onChange? : (event?: any) => void
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
 */
 
 const MessagebarSheetImage = forwardRef((props, ref) => {

--- a/src/react/components/messagebar-sheet-item.jsx
+++ b/src/react/components/messagebar-sheet-item.jsx
@@ -8,6 +8,7 @@ import { colorClasses } from '../shared/mixins.js';
   style?: React.CSSProperties;
   COLOR_PROPS
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
 */
 
 const MessagebarSheetItem = forwardRef((props, ref) => {

--- a/src/react/components/messagebar-sheet.jsx
+++ b/src/react/components/messagebar-sheet.jsx
@@ -7,6 +7,7 @@ import { colorClasses } from '../shared/mixins.js';
   className?: string;
   style?: React.CSSProperties;
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
   COLOR_PROPS
 */
 

--- a/src/react/components/messagebar.jsx
+++ b/src/react/components/messagebar.jsx
@@ -42,6 +42,7 @@ import { Messagebar } from 'framework7/types';
   onMessagebarAttachmentClick? : (instance?: Messagebar.Messagebar, attachmentEl?: HTMLElement, attachmentElIndex?: number) => void
   onMessagebarResizePage? : (instance?: Messagebar.Messagebar) => void
   ref?: React.MutableRefObject<{el: HTMLElement | null; f7Messagebar: () => Messagebar.Messagebar}>;
+  children?: React.ReactNode;
 */
 
 const Messagebar = forwardRef((props, ref) => {

--- a/src/react/components/messages-title.jsx
+++ b/src/react/components/messages-title.jsx
@@ -7,6 +7,7 @@ import { colorClasses } from '../shared/mixins.js';
   className?: string;
   style?: React.CSSProperties;
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
   COLOR_PROPS
 */
 

--- a/src/react/components/messages.jsx
+++ b/src/react/components/messages.jsx
@@ -30,6 +30,7 @@ import { Messages } from 'framework7/types';
   renderMessage? : Function
   init? : boolean
   ref?: React.MutableRefObject<{el: HTMLElement | null; f7Messages: () => Messages.Messages}>;
+  children?: React.ReactNode;
   COLOR_PROPS
 */
 

--- a/src/react/components/nav-left.jsx
+++ b/src/react/components/nav-left.jsx
@@ -18,6 +18,7 @@ import Link from './link.js';
   onBackClick? : (event?: any) => void;
   onClickBack? : (event?: any) => void;
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
 */
 
 const NavLeft = forwardRef((props, ref) => {

--- a/src/react/components/nav-right.jsx
+++ b/src/react/components/nav-right.jsx
@@ -8,6 +8,7 @@ import { colorClasses } from '../shared/mixins.js';
   style?: React.CSSProperties;
   sliding? : boolean;
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
   COLOR_PROPS
 */
 

--- a/src/react/components/nav-title-large.jsx
+++ b/src/react/components/nav-title-large.jsx
@@ -7,6 +7,7 @@ import { colorClasses } from '../shared/mixins.js';
   className?: string;
   style?: React.CSSProperties;
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
   COLOR_PROPS
 */
 

--- a/src/react/components/nav-title.jsx
+++ b/src/react/components/nav-title.jsx
@@ -10,6 +10,7 @@ import { colorClasses } from '../shared/mixins.js';
   subtitle? : string;
   sliding? : boolean;
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
   COLOR_PROPS
 */
 

--- a/src/react/components/navbar.jsx
+++ b/src/react/components/navbar.jsx
@@ -39,6 +39,7 @@ import NavRight from './nav-right.js';
   onBackClick? : (event?: any) => void
   onClickBack? : (event?: any) => void
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
 */
 
 const Navbar = forwardRef((props, ref) => {

--- a/src/react/components/page-content.jsx
+++ b/src/react/components/page-content.jsx
@@ -37,6 +37,7 @@ import { f7ready, f7 } from '../shared/f7.js';
   onTabShow? : (el?: HTMLElement) => void
   onTabHide? : (el?: HTMLElement) => void
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
 */
 
 const PageContent = forwardRef((props, ref) => {

--- a/src/react/components/page.jsx
+++ b/src/react/components/page.jsx
@@ -54,6 +54,7 @@ import PageContent from './page-content.js';
   onPageTabShow? : (...args: any[]) => void
   onPageTabHide? : (...args: any[]) => void
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
 */
 
 const Page = forwardRef((props, ref) => {

--- a/src/react/components/panel.jsx
+++ b/src/react/components/panel.jsx
@@ -44,6 +44,7 @@ import { Panel } from 'framework7/types';
   onPanelCollapsedBreakpoint? : (event?: any) => void
   onPanelResize? : (...args: any[]) => void
   ref?: React.MutableRefObject<{el: HTMLElement | null; f7Panel: () => Panel.Panel}>;
+  children?: React.ReactNode;
 */
 
 const Panel = forwardRef((props, ref) => {

--- a/src/react/components/photo-browser.jsx
+++ b/src/react/components/photo-browser.jsx
@@ -45,6 +45,7 @@ import { PhotoBrowser } from 'framework7/types';
   onPhotoBrowserClosed? : (...args: any[]) => void
   onPhotoBrowserSwipeToClose? : (...args: any[]) => void
   ref?: React.MutableRefObject<{el: HTMLElement | null; f7PhotoBrowser: () => PhotoBrowser.PhotoBrowser; open: () => void; close: () => void;}>;
+  children?: React.ReactNode;
 */
 
 const PhotoBrowser = forwardRef((props, ref) => {

--- a/src/react/components/pie-chart.jsx
+++ b/src/react/components/pie-chart.jsx
@@ -12,6 +12,7 @@ import { f7 } from '../shared/f7.js';
   formatTooltip?: (data: {index: number; value: number; label: string; color: string; percentage: number}) => void;
   onSelect? : (index: number | null, item: {value: number; label: string; color: string}) => void
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
 */
 
 const PieChart = forwardRef((props, ref) => {

--- a/src/react/components/popover.jsx
+++ b/src/react/components/popover.jsx
@@ -30,6 +30,7 @@ import { Popover } from 'framework7/types';
   onPopoverClose? : (instance?: Popover.Popover) => void
   onPopoverClosed? : (instance?: Popover.Popover) => void
   ref?: React.MutableRefObject<{el: HTMLElement | null; f7Popover: () => Popover.Popover}>;
+  children?: React.ReactNode;
 */
 
 const Popover = forwardRef((props, ref) => {

--- a/src/react/components/popup.jsx
+++ b/src/react/components/popup.jsx
@@ -35,6 +35,7 @@ import { Popup } from 'framework7/types';
   onPopupClose? : (instance?: Popup.Popup) => void
   onPopupClosed? : (instance?: Popup.Popup) => void
   ref?: React.MutableRefObject<{el: HTMLElement | null; f7Popup: () => Popup.Popup}>;
+  children?: React.ReactNode;
 */
 
 const Popup = forwardRef((props, ref) => {

--- a/src/react/components/preloader.jsx
+++ b/src/react/components/preloader.jsx
@@ -9,6 +9,7 @@ import { useTheme } from '../shared/use-theme.js';
   style?: React.CSSProperties;
   size? : number | string;
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
   COLOR_PROPS
 */
 

--- a/src/react/components/progressbar.jsx
+++ b/src/react/components/progressbar.jsx
@@ -10,6 +10,7 @@ import { f7 } from '../shared/f7.js';
   progress? : number;
   infinite? : boolean;
   ref?: React.MutableRefObject<{el: HTMLElement | null; set: (progress: number, duration: number) => void}>;
+  children?: React.ReactNode;
   COLOR_PROPS
 */
 

--- a/src/react/components/radio.jsx
+++ b/src/react/components/radio.jsx
@@ -15,6 +15,7 @@ import { colorClasses } from '../shared/mixins.js';
   COLOR_PROPS
   onChange? : (event?: any) => void
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
 */
 
 const Radio = forwardRef((props, ref) => {

--- a/src/react/components/range.jsx
+++ b/src/react/components/range.jsx
@@ -37,6 +37,7 @@ import { Range } from 'framework7/types';
   onRangeChange? : (val?: any) => void
   onRangeChanged? : (val?: any) => void
   ref?: React.MutableRefObject<{el: HTMLElement | null; f7Range: () => Range.Range}>;
+  children?: React.ReactNode;
 */
 
 const Range = forwardRef((props, ref) => {

--- a/src/react/components/row.jsx
+++ b/src/react/components/row.jsx
@@ -16,6 +16,7 @@ import { f7ready, f7 } from '../shared/f7.js';
   onClick? : (event?: any) => void
   onGridResize? : (...args: any[]) => void
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
   COLOR_PROPS
 */
 

--- a/src/react/components/searchbar.jsx
+++ b/src/react/components/searchbar.jsx
@@ -53,6 +53,7 @@ import { Searchbar } from 'framework7/types';
   onClickClear? : (event?: any) => void
   onClickDisable? : (event?: any) => void
   ref?: React.MutableRefObject<{el: HTMLElement | null; f7Searchbar: () => Searchbar.Searchbar;}>;
+  children?: React.ReactNode;
 */
 
 const Searchbar = forwardRef((props, ref) => {

--- a/src/react/components/segmented.jsx
+++ b/src/react/components/segmented.jsx
@@ -20,6 +20,7 @@ import { colorClasses } from '../shared/mixins.js';
   strongAurora? : boolean
   tag? : string
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
   COLOR_PROPS
 */
 

--- a/src/react/components/sheet.jsx
+++ b/src/react/components/sheet.jsx
@@ -38,6 +38,7 @@ import { Sheet } from 'framework7/types';
   onSheetClose? : (instance?: Sheet.Sheet) => void
   onSheetClosed? : (instance?: Sheet.Sheet) => void
   ref?: React.MutableRefObject<{el: HTMLElement | null; f7Sheet: () => Sheet.Sheet;}>;
+  children?: React.ReactNode;
 */
 
 const Sheet = forwardRef((props, ref) => {

--- a/src/react/components/stepper.jsx
+++ b/src/react/components/stepper.jsx
@@ -58,6 +58,7 @@ import { Stepper } from 'framework7/types';
   onStepperMinusClick? : (event?: any, stepper?: Stepper.Stepper) => void
   onStepperPlusClick? : (event?: any, stepper?: Stepper.Stepper) => void
   ref?: React.MutableRefObject<{el: HTMLElement | null; f7Stepper: () => Stepper.Stepper;}>;
+  children?: React.ReactNode;
 */
 
 const Stepper = forwardRef((props, ref) => {

--- a/src/react/components/subnavbar.jsx
+++ b/src/react/components/subnavbar.jsx
@@ -10,6 +10,7 @@ import { colorClasses } from '../shared/mixins.js';
   title? : string
   inner? : boolean
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
   COLOR_PROPS
 */
 

--- a/src/react/components/swipeout-actions.jsx
+++ b/src/react/components/swipeout-actions.jsx
@@ -10,6 +10,7 @@ import { colorClasses } from '../shared/mixins.js';
   right? : boolean
   side? : string
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
   COLOR_PROPS
 */
 

--- a/src/react/components/swipeout-button.jsx
+++ b/src/react/components/swipeout-button.jsx
@@ -16,6 +16,7 @@ import { colorClasses } from '../shared/mixins.js';
   COLOR_PROPS
   onClick? : (event?: any) => void
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
 */
 
 const SwipeoutButton = forwardRef((props, ref) => {

--- a/src/react/components/tab.jsx
+++ b/src/react/components/tab.jsx
@@ -16,6 +16,7 @@ import { useAsyncComponent } from '../shared/use-async-component.js';
   onTabShow? : (el?: HTMLElement) => void
   onTabHide? : (el?: HTMLElement) => void
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
 */
 
 const Tab = forwardRef((props, ref) => {

--- a/src/react/components/tabs.jsx
+++ b/src/react/components/tabs.jsx
@@ -16,6 +16,7 @@ import { SwiperOptions } from 'swiper';
   swiperParams? : SwiperOptions
   COLOR_PROPS
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
 */
 
 const Tabs = forwardRef((props, ref) => {

--- a/src/react/components/text-editor.jsx
+++ b/src/react/components/text-editor.jsx
@@ -35,6 +35,7 @@ import { TextEditor } from 'framework7/types';
   onTextEditorInsertLink?: (...args: any[]) => void
   onTextEditorInsertImage?: (...args: any[]) => void
   ref?: React.MutableRefObject<{el: HTMLElement | null; f7TextEditor: () => TextEditor.TextEditor;}>;
+  children?: React.ReactNode;
 */
 
 const TextEditor = forwardRef((props, ref) => {

--- a/src/react/components/toggle.jsx
+++ b/src/react/components/toggle.jsx
@@ -26,6 +26,7 @@ import { Toggle } from 'framework7/types';
   onToggleChange? : (...args: any[]) => void
   onChange? : (event?: any) => void
   ref?: React.MutableRefObject<{el: HTMLElement | null; f7Toggle: () => Toggle.Toggle;}>;
+  children?: React.ReactNode;
 */
 
 const Toggle = forwardRef((props, ref) => {

--- a/src/react/components/toolbar.jsx
+++ b/src/react/components/toolbar.jsx
@@ -31,6 +31,7 @@ import { TabbarContext } from '../shared/tabbar-context.js';
   onToolbarHide? : (...args: any[]) => void
   onToolbarShow? : (...args: any[]) => void
   ref?: React.MutableRefObject<{el: HTMLElement | null; hide: () => void; show: () => void;}>;
+  children?: React.ReactNode;
 */
 
 const Toolbar = forwardRef((props, ref) => {

--- a/src/react/components/treeview-item.jsx
+++ b/src/react/components/treeview-item.jsx
@@ -32,6 +32,7 @@ import { f7ready, f7 } from '../shared/f7.js';
   onTreeviewClose? : (el?: HTMLElement) => void
   onTreeviewLoadChildren? : (el?: HTMLElement, done?: any) => void
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
 */
 
 const TreeviewItem = forwardRef((props, ref) => {

--- a/src/react/components/treeview.jsx
+++ b/src/react/components/treeview.jsx
@@ -7,6 +7,7 @@ import { colorClasses } from '../shared/mixins.js';
   className?: string;
   style?: React.CSSProperties;
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
   COLOR_PROPS
 */
 

--- a/src/react/components/view.jsx
+++ b/src/react/components/view.jsx
@@ -85,6 +85,7 @@ import { RouterContext } from '../shared/router-context.js';
   onTabShow? : (el?: HTMLElement) => void
   onTabHide? : (el?: HTMLElement) => void
   ref?: React.MutableRefObject<{el: HTMLElement | null; f7View: () => View.View}>;
+  children?: React.ReactNode;
 */
 
 const View = forwardRef((props, ref) => {

--- a/src/react/components/views.jsx
+++ b/src/react/components/views.jsx
@@ -8,6 +8,7 @@ import { colorClasses } from '../shared/mixins.js';
   style?: React.CSSProperties;
   tabs?: boolean;
   ref?: React.MutableRefObject<{el: HTMLElement | null}>;
+  children?: React.ReactNode;
   COLOR_PROPS
 */
 


### PR DESCRIPTION
React v18 no longer has children prop implicitly.  Needs to be added explicitly.  I quasi-tested this locally by performing the same change in my node-modules folder, but I'm not set up to do real tests of f7.  Please validate?

https://solverfox.dev/writing/no-implicit-children/