### PR TITLE
fix and export framework7-bundle.less

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,6 +11,7 @@
     "./lite/bundle": "./framework7-lite-bundle.esm.js",
     "./lite-bundle": "./framework7-lite-bundle.esm.js",
     "./less": "./framework7.less",
+    "./less/bundle": "./framework7-bundle.less",
     "./css": "./framework7.css",
     "./css/rtl": "./framework7-rtl.css",
     "./css/bundle": "./framework7-bundle.css",

--- a/scripts/build-core-styles.js
+++ b/scripts/build-core-styles.js
@@ -45,7 +45,7 @@ function copyLess(config, components, cb) {
   const lessBundleContent = lessContent.replace(
     '//IMPORT_COMPONENTS',
     components
-      .map((component) => `@import url('./components/${component}/${component}.less');`)
+      .map((component) => `@import './components/${component}/${component}.less';`)
       .join('\n'),
   );
   fs.writeFileSync(`${output}/framework7-bundle.less`, lessBundleContent);


### PR DESCRIPTION
Style customization is quite powerfull. However having to maintain an up to date list of components' `.less` files is tedious. This patch enables tweaking themes, colors, rtl (without worring about the components' `.less` files:

```
// file: framework.custom.less
// core
@import 'framework7/less/bundle';

// include/exclude themes
@includeIosTheme: true;
@includeMdTheme: true;
@includeAuroraTheme: true;

// include/exclude dark theme
@includeDarkTheme: true;
// include/exclude light theme
@includeLightTheme: true;

// Theme color
@themeColor: #007aff;

// Extra colors
@colors: {
  red: #ff3b30;
  green: #4cd964;
  blue: #2196f3;
  pink: #ff2d55;
  yellow: #ffcc00;
  orange: #ff9500;
  purple: #9c27b0;
  deeppurple: #673ab7;
  lightblue: #5ac8fa;
  teal: #009688;
  lime: #cddc39;
  deeporange: #ff6b22;
  gray: #8e8e93;
  white: #ffffff;
  black: #000000;
};

// change to true to generate RTL styles
@rtl: false;
}
```

The `url` removal is necessary to make `vite` happy...