### PR TITLE
Add export props interface svelte fixes #4023

### DIFF
--- a/scripts/build-svelte-typings.js
+++ b/scripts/build-svelte-typings.js
@@ -17,7 +17,7 @@ interface {{componentName}}Props extends svelte.JSX.HTMLAttributes<HTMLElementTa
 
 {{EXTENDS}}
 
-class {{componentName}} extends SvelteComponentTyped<
+declare class {{componentName}} extends SvelteComponentTyped<
   {{componentName}}Props,
   { {{EVENTS}} },
   { {{SLOTS}} }

--- a/scripts/build-svelte-typings.js
+++ b/scripts/build-svelte-typings.js
@@ -23,6 +23,7 @@ class {{componentName}} extends SvelteComponentTyped<
   { {{SLOTS}} }
 > {}
 
+export { {{componentName}}Props };
 export default {{componentName}};
 `;
 


### PR DESCRIPTION
Svelte typings are too missing the exported interface. So this is can be considered an extension of #4023 
