### PR TITLE
fix(vue): Improve type definitions for framework7-vue/bundle

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -10,6 +10,11 @@
     "./shared/*": "./shared/*"
   },
   "typings": "framework7-vue.d.ts",
+  "typesVersions": {
+    "*": {
+      "bundle": ["framework7-vue-bundle.d.ts"]
+    }
+  },
   "web-types": "framework7-vue-web-types.json",
   "repository": {
     "type": "git",

--- a/src/vue/framework7-vue-bundle.d.ts
+++ b/src/vue/framework7-vue-bundle.d.ts
@@ -1,0 +1,5 @@
+export * from ".";
+
+declare const registerComponents: (app: any) => void;
+
+export { registerComponents };

--- a/src/vue/framework7-vue.d.ts
+++ b/src/vue/framework7-vue.d.ts
@@ -20,7 +20,6 @@ declare const f7ready: (callback: (f7: Framework7) => void) => void;
 
 declare const Framework7Vue: Framework7Plugin;
 
-declare const registerComponents: (app: any) => void;
 
 interface useStore {
   (store: Store, getter: string): any;
@@ -30,5 +29,5 @@ interface useStore {
 declare const useStore: useStore;
 
 // EXPORT_COMPONENTS
-export { f7, f7ready, theme, registerComponents, useStore };
+export { f7, f7ready, theme, useStore };
 export default Framework7Vue;


### PR DESCRIPTION
The framework7-vue type definitions inaccurately suggest `registerComponents` is exported by the `framework7-vue` module. The `package.json` also lacks any way for TypeScript to tell what the type definitions are for the bundle module.

This slight adjust fixes both of these requirements. The hint on using `typeVersions` comes from https://stackoverflow.com/a/70020984/156169

Before these fixes:
![image](https://user-images.githubusercontent.com/1052079/191178355-2660e06e-71e6-4851-ae26-e8c93b095a65.png)


After these fixes, this is what TypeScript reports:
![image](https://user-images.githubusercontent.com/1052079/191178549-e202bfc5-c00a-44e1-88f6-ebd7099cad47.png)