### PR TITLE
fix(core): reset allowPageChange after duplicated async back navigation (#4111)

### DIFF
--- a/src/core/modules/router/back.js
+++ b/src/core/modules/router/back.js
@@ -558,6 +558,7 @@ function loadBack(router, backParams, backOptions, ignorePageChange) {
     !(options.reloadCurrent || options.reloadPrevious) &&
     !router.params.allowDuplicateUrls
   ) {
+    router.allowPageChange = true;
     return false;
   }
 


### PR DESCRIPTION
Fixes #4111

This duplicates the fix in https://github.com/framework7io/framework7/commit/83abadd66d0d003fdcaf0857d70f37ee8d9e6447, except in the `back` pathway