### PR TITLE
Update notification.d.ts

### DIFF
--- a/src/core/components/notification/notification.d.ts
+++ b/src/core/components/notification/notification.d.ts
@@ -48,7 +48,7 @@ export namespace Notification {
     /** Element to mount notifications to. (default app.el) */
     containerEl?: HTMLElement | CSSSelector;
     /** Custom function to render Notification. Must return notification html. */
-    render?: () => string;
+    render?: (notification: Notification) => string;
     /** Object with events handlers.. */
     on?: {
       [event in keyof Events]?: Events[event];


### PR DESCRIPTION
Notification `render` method is missing parameter type, which should be the notification itself according to https://github.com/framework7io/framework7/blob/master/src/core/components/notification/notification-class.js#L203