### PR TITLE
fix(svelte): Custom icon reset class on update

### DIFF
--- a/src/svelte/components/icon.svelte
+++ b/src/svelte/components/icon.svelte
@@ -47,7 +47,7 @@
     }
 
     if (prop === 'icon') {
-      classes[value] = true;
+      classes = { icon: true, [value]: true };
     }
   } else {
     classes = {


### PR DESCRIPTION
If I dynamically change a custom icon (themeIcon), the class would be appended instead of replaced. This is because we only set the class to `true` via `classes[value] = true;` but never delete the old classes that are no longer passed as arguments. To fix this, I just replace the classes object with a new one.

``` svelte
<Link
  ...
  iconMd={pinnedState ? "icon:mdi mdi-pin-off" : "icon:mdi mdi-pin"}
  ...
/>
```

### Example before change of pinnedState
``` html
<i class="icon mdi mdi-pin" style=""> </i>
```
### Example wrong
``` html
<i class="icon mdi mdi-pin mdi mdi-pin-off" style=""> </i>
```
### Example correct
``` html
<i class="icon mdi mdi-pin-off" style=""> </i>
```
