### PR TITLE
Fix router-class.js for correct navigate if used route path format like `/:optionalParam(any+[regexp]+)?`

### DIFF
--- a/src/core/modules/router/router-class.js
+++ b/src/core/modules/router/router-class.js
@@ -574,6 +574,11 @@ class Router extends Framework7Class {
       }
     }
     const url = router.constructRouteUrl(route, { params, query });
+
+    if (url === '') {
+      return '/'
+    }
+
     if (!url) {
       throw new Error(`Framework7: can't construct URL for route with name "${name}"`);
     }


### PR DESCRIPTION
For example:
We have 2 routes
```ts
const view: View.Parameters = {
    routes: [
        {
            name: 'home',
            path: '/:anyOptionalParam(any+[regex]+)?',
        },
        {
            name: 'about',
            path: '/about',
        },
    ],
}

```
1. If started at 'about' page (http://localhost/about)
2. Call 
```ts
currentViewRouter.navigate({
    name: 'home'
})
```
3. Have error `Uncaught (in promise) Error: Framework7: can't construct URL for route with name "home"`
