### PR TITLE
Fix "Resizable reveal panel" handler position

### DIFF
--- a/src/core/components/panel/panel.less
+++ b/src/core/components/panel/panel.less
@@ -276,7 +276,7 @@ html {
   .panel-left.panel-floating & {
     right: -3px;
   }
-  .panel-left.panel-reveal,
+  .panel-left.panel-reveal &,
   .panel-left.panel-push & {
     right: 0;
   }
@@ -284,7 +284,7 @@ html {
   .panel-right.panel-floating & {
     left: -3px;
   }
-  .panel-right.panel-reveal,
+  .panel-right.panel-reveal &,
   .panel-right.panel-push & {
     left: 0;
   }


### PR DESCRIPTION
This commit fixes issue When using reveal panel and resizable panel (panel-reveal panel-resizable) the position of the handler is not set (on ltr it will be wrong for the panel-left.

