### PR TITLE
fix(theme): insert theme stylesheet first to allow overriding (#4219)

### DIFF
--- a/src/core/components/app/app-class.js
+++ b/src/core/components/app/app-class.js
@@ -138,7 +138,7 @@ class Framework7 extends Framework7Class {
     const document = getDocument();
     if (!app.colorsStyleEl) {
       app.colorsStyleEl = document.createElement('style');
-      document.head.insertNode(document.head.firstChild, app.colorsStyleEl);
+      document.head.prepend(app.colorsStyleEl);
     }
 
     app.colorsStyleEl.textContent = app.utils.colorThemeCSSStyles(app.colors);

--- a/src/core/components/app/app-class.js
+++ b/src/core/components/app/app-class.js
@@ -138,7 +138,7 @@ class Framework7 extends Framework7Class {
     const document = getDocument();
     if (!app.colorsStyleEl) {
       app.colorsStyleEl = document.createElement('style');
-      document.head.appendChild(app.colorsStyleEl);
+      document.head.insertNode(document.head.firstChild, app.colorsStyleEl);
     }
 
     app.colorsStyleEl.textContent = app.utils.colorThemeCSSStyles(app.colors);


### PR DESCRIPTION
Resolves #4219 by putting the computed stylesheet higher in the document. With cascading stylesheets, the **last** stylesheet overrides previous stylesheet rules.