### PR TITLE
Bugfix: Fix there are types at 'framework7.d.ts' but this result could not be resolved when respecting package.json

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,12 +4,30 @@
   "description": "Full featured mobile HTML framework for building iOS & Android apps",
   "type": "module",
   "exports": {
-    ".": "./framework7.esm.js",
-    "./core": "./framework7.esm.js",
-    "./bundle": "./framework7-bundle.esm.js",
-    "./lite": "./framework7-lite.esm.js",
-    "./lite/bundle": "./framework7-lite-bundle.esm.js",
-    "./lite-bundle": "./framework7-lite-bundle.esm.js",
+    ".": {
+      "import": "./framework7.esm.js",
+      "types": "./framework7.d.ts"
+    },
+    "./core": {
+      "import": "./framework7.esm.js",
+      "types": "./framework7.d.ts"
+    },
+    "./bundle": {
+      "import": "./framework7-bundle.esm.js",
+      "types": "./framework7.d.ts"
+    },
+    "./lite": {
+      "import": "./framework7-lite.esm.js",
+      "types": "./framework7.d.ts"
+    },
+    "./lite/bundle": {
+      "import": "./framework7-lite-bundle.esm.js",
+      "types": "./framework7.d.ts"
+    },
+    "./lite-bundle": {
+      "import": "./framework7-lite-bundle.esm.js",
+      "types": "./framework7.d.ts"
+    },
     "./less": "./framework7.less",
     "./less/bundle": "./framework7-bundle.less",
     "./css": "./framework7.css",


### PR DESCRIPTION
Fixes #4181

I'm importing `framework7` in an astro project (vite) and I get the same error as in the above issue. 

> There are types at 'Documents/my-project/node_modules/framework7/framework7.d.ts', but this result could not be resolved when respecting package.json "exports". The 'framework7' library may need to update its package.json or typings.

The above seems to fix it. I know very little about this project so if this isn't the right approach (or it causes other issues) feel free to close.

Using: 
node 18
Typescript 5