### PR TITLE
Fix param type of calendar parameter formatValue

### DIFF
--- a/src/core/components/calendar/calendar.d.ts
+++ b/src/core/components/calendar/calendar.d.ts
@@ -93,7 +93,7 @@ export namespace Calendar {
     /** Date ranges you want to add custom CSS class for additional styling. Look below for accepted format. */
     rangesClasses?: RangeClass[];
     /** Function to format input value, should return new/formatted string value. values is array where each item represents selected date. */
-    formatValue?: (values: Date) => string;
+    formatValue?: (values: Date[]) => string;
     /** Intl locale string. see https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat */
     locale?: string;
     /** Array with full month names. (default "auto") */


### PR DESCRIPTION
Change parameter type of values to an array, in line with the JSDoc comment.

Fixes #4236