### PR TITLE
Fix sorting arrow direction

### DIFF
--- a/src/core/components/data-table/data-table.less
+++ b/src/core/components/data-table/data-table.less
@@ -178,10 +178,9 @@
       opacity: 0.87 !important;
     }
   }
-  .sortable-cell.sortable-asc {
+  .sortable-cell.sortable-desc {
   }
-  .sortable-cell.sortable-desc,
-  .sortable-cell.sortable-desc,
+  .sortable-cell.sortable-asc,
   .table-head-label {
     &:after,
     &:before {


### PR DESCRIPTION
Sort arrow in data-table is wrong. When adding `sortable-asc`, the arrow is down, when adding `sortable-desc`, the arrow is up. 
The PR would fix the arrow direction issue.
