### PR TITLE
Svelte List Component: Add ul to list of attributes

### DIFF
--- a/src/svelte/components/list.svelte
+++ b/src/svelte/components/list.svelte
@@ -84,6 +84,7 @@
     className,
     'list',
     {
+      ul,
       inset,
       'inset-ios': insetIos,
       'inset-md': insetMd,


### PR DESCRIPTION
I've noticed that the `ul` prop isn't included in the `ListProps` type. I think this is the only change that is required to fix it (I'm assuming the types files are autogenerated during the build process (however, I've not found a way to actually do that running the various build scripts).

Let me know if there is anything else needed in order to get this type working properly. 