### PR TITLE
Removed the block title in Panel Right (React/Svelte/Vue)

### DIFF
--- a/kitchen-sink/react/src/pages/panel-right.jsx
+++ b/kitchen-sink/react/src/pages/panel-right.jsx
@@ -4,7 +4,6 @@ import { Page, Navbar, BlockTitle, Block, List, ListItem, Link } from 'framework
 export default () => (
   <Page>
     <Navbar title="Right Panel"></Navbar>
-    <BlockTitle>Left Panel</BlockTitle>
     <Block>
       <p>
         This is a right side panel. You can close it by clicking outsite or on this link:

--- a/kitchen-sink/svelte/src/pages/panel-right.svelte
+++ b/kitchen-sink/svelte/src/pages/panel-right.svelte
@@ -4,7 +4,6 @@
 
 <Page>
   <Navbar title="Right Panel" />
-  <BlockTitle>Left Panel</BlockTitle>
   <Block>
     <p>
       This is a right side panel. You can close it by clicking outsite or on this link:

--- a/kitchen-sink/vue/src/pages/panel-right.vue
+++ b/kitchen-sink/vue/src/pages/panel-right.vue
@@ -1,7 +1,6 @@
 <template>
   <f7-page>
     <f7-navbar title="Right Panel"></f7-navbar>
-    <f7-block-title>Left Panel</f7-block-title>
     <f7-block>
       <p>
         This is a right side panel. You can close it by clicking outsite or on this link:


### PR DESCRIPTION
Removed the block title (which also has a typo: "**Left**" instead of "**Right**") in Panel Right (React/Svelte/Vue) for consistency with the Core version.

Thank to @szv for having detected it (#4291) 