### PR TITLE
fix: Svelte popup swipeToClose default

### DIFF
--- a/src/svelte/components/popup.svelte
+++ b/src/svelte/components/popup.svelte
@@ -19,7 +19,7 @@
   export let backdropEl = undefined;
   export let closeByBackdropClick = undefined;
   export let closeOnEscape = undefined;
-  export let swipeToClose = false;
+  export let swipeToClose = undefined;
   export let swipeHandler = undefined;
   export let push = undefined;
   export let containerEl = undefined;


### PR DESCRIPTION
The `swipeToClose` parameter of the Svelte Popup component previously defaulted to a value of `false`, while other parameters defaulted to `undefined`. As a result, the default `swipeToClose` value specified in the global app parameters was ignored.

This was causing problems for me in the context of routed modals - I have some routes configured with `options: {openIn: 'popup'}`, however, there is currently no way when using `framework7-svelte` to set these popups to allow the `swipeToClose` behaviour.