### PR TITLE
fixes #4304 - popup.params sometimes undefined

### DIFF
--- a/src/core/components/popup/popup-class.js
+++ b/src/core/components/popup/popup-class.js
@@ -184,7 +184,7 @@ class Popup extends Modal {
       $el.transition(0);
 
       if (
-        typeof popup.params.swipeToClose === 'string' &&
+        popup.params && typeof popup.params.swipeToClose === 'string' &&
         direction !== popup.params.swipeToClose
       ) {
         $el.transform('');


### PR DESCRIPTION
In core/vanilla - seeing this error from iOS users - managed to track it down to specifically when users use the iOS app switcher/or the app loses focus whilst the popup is open - when user returns to the app the error is triggered:

undefined is not an object (evaluating 'i.params.swipeToClose')

![framework7-ss](https://github.com/user-attachments/assets/e54ee9dc-390f-4c8a-af85-3e3e5e59132b)
