### PR TITLE
fix(subnavbar): Remove whitespace between a mixin name and parentheses for a mixin call

### DIFF
--- a/src/core/components/subnavbar/subnavbar-md.less
+++ b/src/core/components/subnavbar/subnavbar-md.less
@@ -1,7 +1,7 @@
 .md {
   .subnavbar {
     height: var(--f7-subnavbar-height);
-    .ltr ({
+    .ltr({
       .right {
         margin-left: auto;
       }
@@ -9,7 +9,7 @@
         right: 16px;
       }
     });;
-    .rtl ({
+    .rtl({
       .right {
         margin-right: auto;
       }


### PR DESCRIPTION
Fix a deprecated warning "Whitespace between a mixin name and parentheses for a mixin call is deprecated" when less is upgraded to 4.3.0
