### PR TITLE
fix(core): fixed routerAjaxStart is never triggered

### DIFF
--- a/src/core/modules/router/router-class.js
+++ b/src/core/modules/router/router-class.js
@@ -789,9 +789,13 @@ class Router extends Framework7Class {
         }
       }
       router.xhrAbortController = new AbortController();
+      const options = {
+        method: 'GET',
+        signal: router.xhrAbortController.signal,
+      };
+      router.emit('routerAjaxStart', options);
       let fetchRes;
-      fetch(url, { signal: router.xhrAbortController.signal, method: 'GET' })
-        .then((res) => {
+      fetch(url, options).then(res => {
           fetchRes = res;
           return res.text();
         })


### PR DESCRIPTION
### Issue: [routerAjaxStart never triggered #4303](https://github.com/framework7io/framework7/issues/4303)

This commit should provide you with a trigger for the '**routerAjaxStart**' event, which you can also use to change its options.

Example:
```js
var app = new Framework7({
	on: {
		routerAjaxStart: function (options) {
			options.headers = new Headers();
			options.headers.set('custom-header', 'custom-header-value');
		},
	}
}
```