### PR TITLE
Prevent chip delete event from bubbling

### DIFF
--- a/src/react/components/chip.jsx
+++ b/src/react/components/chip.jsx
@@ -45,6 +45,7 @@ const Chip = (props) => {
   };
 
   const onDeleteClick = (event) => {
+    event.stopPropagation();
     emit(props, 'delete', event);
   };
 

--- a/src/svelte/components/chip.svelte
+++ b/src/svelte/components/chip.svelte
@@ -44,6 +44,7 @@
   const icon = $derived(useIcon(restProps));
 
   function onDeleteClick(e) {
+    e.stopPropagation();
     restProps.onDelete?.(e);
     restProps.ondelete?.(e);
   }

--- a/src/vue/components/chip.vue
+++ b/src/vue/components/chip.vue
@@ -43,6 +43,7 @@ export default {
     const elRef = ref(null);
 
     const onDeleteClick = (event) => {
+      event.stopPropagation();
       emit('delete', event);
     };
 


### PR DESCRIPTION
Added event.stopPropagation() to the delete handlers in React, Svelte, and Vue chip components to prevent the delete event from bubbling up the DOM tree.