### PR TITLE
fix(svelte): add inputmode param to input component

### DIFF
--- a/src/svelte/components/input.svelte
+++ b/src/svelte/components/input.svelte
@@ -12,6 +12,7 @@
     type = undefined,
     name = undefined,
     value = undefined,
+    inputmode = undefined,
     placeholder = undefined,
     inputId = undefined,
     size = undefined,
@@ -382,6 +383,7 @@
         {placeholder}
         id={inputId}
         {size}
+        {inputmode}
         {accept}
         {autocomplete}
         {autocorrect}
@@ -451,6 +453,7 @@
         {placeholder}
         id={inputId}
         {size}
+        {inputmode}
         {accept}
         {autocomplete}
         {autocorrect}
@@ -561,6 +564,7 @@
     {placeholder}
     id={inputId}
     {size}
+    {inputmode}
     {accept}
     {autocomplete}
     {autocorrect}
@@ -642,6 +646,7 @@
     {placeholder}
     id={inputId}
     {size}
+    {inputmode}
     {accept}
     {autocomplete}
     {autocorrect}


### PR DESCRIPTION
Adds the `inputmode` param to the Input component in Svelte, exactly the same way it's already implemented in ListInput.

`inputmode` is already used in ListInput, and the documentation already lists inputmode as existing for both ListInput and Input as well, so I assume this param was just accidentally missed for Input.
