### PR TITLE
fix: handle pointercancel in tabbar highlight to prevent stale touch state

### DIFF
--- a/src/core/components/toolbar/tabbar-highlight.js
+++ b/src/core/components/toolbar/tabbar-highlight.js
@@ -100,6 +100,18 @@ export const initTabbarHighlight = (el) => {
       unsetHighlightOnTouch(data);
       stopAnimation(data);
     }
+    if (e.type === 'pointercancel') {
+      if (!data.touched) return;
+      data.touched = false;
+      data.moved = false;
+      data.setTransform = null;
+      stopAnimation(data);
+      if (highlightEl) {
+        highlightEl.classList.remove('tab-link-highlight-pressed');
+        highlightEl.style.transform = `translateX(${data.activeIndex * 100}%)`;
+        highlightEl.style.transitionTimingFunction = '';
+      }
+    }
   };
   el.addEventListener('touchstart', el.f7ToolbarOnPointer, { passive: false });
   el.addEventListener('pointerdown', el.f7ToolbarOnPointer, { passive: false });


### PR DESCRIPTION
## Summary

Fixes #4380

The `pointercancel` event listener was already registered on `document` in `initTabbarHighlight`, but the `f7ToolbarOnPointer` handler had no case for `e.type === 'pointercancel'`. This caused `data.touched` to remain `true` after the pointer sequence was cancelled by the system (e.g., when the app is backgrounded on iOS/Android or a browser tab loses focus).

On resume, the next `pointerup` anywhere on `document` would trigger `unsetHighlightOnTouch()`, which calculates the closest tab from the touch coordinates and calls `.click()` — switching tabs unintentionally.

## Changes

Added a `pointercancel` handler that:
- Resets `data.touched` and `data.moved` to `false`
- Clears `data.setTransform`
- Stops the animation frame
- Removes the `tab-link-highlight-pressed` CSS class
- Restores the highlight position to the currently active tab (`data.activeIndex`) without triggering any click

This mirrors the cleanup logic of `pointerup` but intentionally skips `unsetHighlightOnTouch()` to avoid triggering a tab change.

## Test Plan

1. Open a Framework7 app with iOS theme and tabbar using `ToolbarPane`
2. Tap a tab, then background the app (or switch browser tabs)
3. Resume the app (or switch back) and tap anywhere
4. Verify that no unintended tab switch occurs
5. Verify that normal tabbar interaction still works correctly after resume

Made with [Cursor](https://cursor.com)