### PR TITLE
fix incorrect toggle button style in RTL layouts

### DIFF
--- a/src/core/components/toggle/toggle-ios.less
+++ b/src/core/components/toggle/toggle-ios.less
@@ -45,7 +45,8 @@
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
     border-radius: calc(var(--f7-toggle-height) - 4px);
     transition-duration: 300ms;
-    transform: translateX(var(--f7-toggle-knob-tx)) scale(1);
+    .ltr({ transform: translateX(var(--f7-toggle-knob-tx)) scale(1); });
+    .rtl({ transform: translateX(calc(var(--f7-toggle-knob-tx) * -1)) scale(1); });
     position: relative;
     z-index: 1;
     transform-origin: center;
@@ -76,7 +77,8 @@
     }
     .toggle-icon {
       background: transparent;
-      transform: translateX(var(--f7-toggle-knob-tx)) scale(1.4);
+      .ltr({ transform: translateX(var(--f7-toggle-knob-tx)) scale(1.4); });
+      .rtl({ transform: translateX(calc(var(--f7-toggle-knob-tx) * -1)) scale(1.4); });
       &::before {
         opacity: 1;
       }


### PR DESCRIPTION
This PR fixes a display issue with toggle buttons in RTL layouts (#4401). The styles before and after the fix are shown in the table below.

| Before | After |
| --- | --- |
| <img width="130" height="118" alt="image" src="https://github.com/user-attachments/assets/8e4d53ba-c6d7-4cec-81c7-7eaa48340613" /> |  <img width="124" height="109" alt="image" src="https://github.com/user-attachments/assets/21646b39-710c-489d-858c-2f78d0894eca" /> |
| <img width="152" height="120" alt="image" src="https://github.com/user-attachments/assets/2069cffa-61fb-4d51-887c-6e5b36bd5b4d" /> | <img width="132" height="124" alt="image" src="https://github.com/user-attachments/assets/2c6ebb5e-3fc4-4981-9cdf-8b9d961b09b4" /> |
| <img width="144" height="115" alt="image" src="https://github.com/user-attachments/assets/ea87d148-b618-4c4b-bfd2-8df4135babf5" /> | <img width="129" height="121" alt="image" src="https://github.com/user-attachments/assets/95c0e56d-2d96-4788-8eaf-1e31c3e9894f" /> |