### PR TITLE
fix incorrect segmented button style in RTL layouts

### DIFF
--- a/src/core/components/button/button.less
+++ b/src/core/components/button/button.less
@@ -279,17 +279,28 @@ button {
     background-color: var(--f7-segmented-strong-button-active-bg-color);
     border-radius: var(--f7-button-border-radius);
     box-shadow: var(--f7-segmented-strong-button-active-box-shadow);
-    left: var(--f7-segmented-strong-padding);
+    .ltr({ left: var(--f7-segmented-strong-padding); });
+    .rtl({ right: var(--f7-segmented-strong-padding); });
     top: var(--f7-segmented-strong-padding);
     height: calc(100% - var(--f7-segmented-strong-padding) * 2);
     width: var(--f7-segmented-highlight-width);
     z-index: 0;
-    transform: translateX(
-      calc(
-        var(--f7-segmented-highlight-active) * 100% + var(--f7-segmented-highlight-active) *
-          var(--f7-segmented-highlight-between)
-      )
-    );
+    .ltr({
+      transform: translateX(
+        calc(
+          var(--f7-segmented-highlight-active) * 100% + var(--f7-segmented-highlight-active) *
+            var(--f7-segmented-highlight-between)
+        )
+      );
+    });
+    .rtl({
+      transform: translateX(
+        calc(
+          var(--f7-segmented-highlight-active) * -100% - var(--f7-segmented-highlight-active) *
+            var(--f7-segmented-highlight-between)
+        )
+      );
+    });
     transition: 200ms;
   }
 }


### PR DESCRIPTION
This PR fixes a display issue with segmented buttons in RTL layouts (#4402). The styles before and after the fix are shown in the table below.

| Before | After |
| --- | --- |
| <img width="351" height="51" alt="Image" src="https://github.com/user-attachments/assets/cd548793-6a78-4c0b-a73d-a92dd8c4dc10" /> | <img width="352" height="51" alt="image" src="https://github.com/user-attachments/assets/ea9284af-77b1-4b9a-ba7d-afcc69e6c15b" /> |
| <img width="350" height="48" alt="Image" src="https://github.com/user-attachments/assets/e1b30814-d445-4d56-959f-e702da8c9ed5" /> | <img width="361" height="54" alt="image" src="https://github.com/user-attachments/assets/e98cf5c4-658d-4c94-943d-0dacd0a4051f" /> |
| <img width="352" height="48" alt="Image" src="https://github.com/user-attachments/assets/9013b32f-0104-40ca-bcae-35354e5876be" /> | <img width="358" height="48" alt="image" src="https://github.com/user-attachments/assets/e90edcd8-adcc-4b52-a1ad-86b9ed6976df" /> |




